### PR TITLE
Fix APP_DEBUG flag inconsistency and Linux casing bug in error views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ---
 
+## v2.3.2 - Debug Flag & Linux Casing Fixes (2026-06-25)
+
+### Fixed
+- **`APP_DEBUG` now controls exception page detail** — `Start::bootstrapApplication()` was passing `Environment::isDevelopment()` (checks `APP_ENV === 'development'`) to `ErrorHandler`, so `APP_DEBUG=false` with `APP_ENV=development` still showed full stack traces. Changed to `filter_var(Environment::get('APP_DEBUG', 'false'), FILTER_VALIDATE_BOOLEAN)` — one flag, one behavior.
+- **Linux casing bug in error view paths** — `ErrorHandler` built error view paths as `$baseDir . '/common/errors/...'` where `$baseDir` pointed to `src/`. On case-sensitive Linux filesystems `common` ≠ `Common`, so custom 404/500/403 pages silently fell back to the generic HTML fallback. Paths now use `Application::getInstance()->path('src/Common/errors')`.
+- **`ErrorHandler` log path fallback now consistent** — removed the `THIS_DIR`-based fallback in the constructor (which was never defined at call time anyway) in favour of `Application::getInstance()->path('src/logs/...')`. Absolute paths passed from `Start::resolveLogPath()` are still used as-is.
+
+### Deprecated
+- **`App\Etc\ErrorHandler` (static)** — marked `@deprecated` in docblock. The instance-based `App\Etc\Exceptions\ErrorHandler` registered by `Start.php` is the active handler since v2.3.1. The static class is no longer called during bootstrap and will be removed in a future release.
+
+---
+
 ## v2.3.1 - Bootstrap Cleanup & Path Normalization (2026-06-25)
 
 ### Changed

--- a/src/Etc/ErrorHandler.php
+++ b/src/Etc/ErrorHandler.php
@@ -1,35 +1,16 @@
 <?php
 /**
- * ErrorHandler.php - Static Error and Exception Handler
- * 
- * This class provides a simplified static error handling system for upMVC:
- * - Static method-based API (no instantiation required)
- * - PHP error handling (warnings, notices, etc.)
- * - Uncaught exception handling
- * - Fatal error handling (shutdown function)
- * - Daily log rotation (error_YYYY-MM-DD.log)
- * - Debug mode error display
- * 
- * Features:
- * - Automatic log directory creation
- * - JSON log format for easy parsing
- * - Styled error display in debug mode
- * - Integration with upMVC\Config for debug flag
- * - Daily log file rotation
- * 
- * Debug Mode:
- * - Enabled: Shows styled error boxes with stack traces
- * - Disabled: Shows 500 error page for exceptions
- * 
- * Usage:
- * Call ErrorHandler::register() once during bootstrap.
- * 
+ * ErrorHandler.php - Static Error and Exception Handler (DEPRECATED)
+ *
+ * @deprecated Use App\Etc\Exceptions\ErrorHandler instead.
+ *   The instance-based handler (registered by Start.php) is the active
+ *   error handler since v2.3.1. This static class is no longer called
+ *   during bootstrap and will be removed in a future release.
+ *
  * @package upMVC
  * @author BitsHost
  * @copyright 2025 BitsHost
  * @license MIT License
- * @link https://bitshost.biz/
- * @created October 21, 2025
  */
 
 namespace App\Etc;

--- a/src/Etc/Exceptions/ErrorHandler.php
+++ b/src/Etc/Exceptions/ErrorHandler.php
@@ -31,6 +31,7 @@
 
 namespace App\Etc\Exceptions;
 
+use App\Etc\Application;
 use App\Etc\Exceptions\upMVCException;
 use Exception;
 use Throwable;
@@ -85,15 +86,14 @@ class ErrorHandler
     public function __construct(bool $debug = false, string $logFile = 'logs/errors.log')
     {
         $this->debug = $debug;
-        $baseDir = defined('THIS_DIR') ? THIS_DIR : dirname(__DIR__, 2);
         $isAbsolute = str_starts_with($logFile, '/') || preg_match('/^[A-Za-z]:[\\\\\\/]/', $logFile);
-        $this->logFile = $isAbsolute ? $logFile : $baseDir . '/' . $logFile;
-        
-        // Define default error views
+        $this->logFile = $isAbsolute ? $logFile : Application::getInstance()->path('src/logs/' . ltrim($logFile, '/\\'));
+
+        $errorsDir = Application::getInstance()->path('src/Common/errors');
         $this->errorViews = [
-            404 => $baseDir . '/common/errors/404.php',
-            500 => $baseDir . '/common/errors/500.php',
-            403 => $baseDir . '/common/errors/403.php'
+            404 => $errorsDir . '/404.php',
+            500 => $errorsDir . '/500.php',
+            403 => $errorsDir . '/403.php'
         ];
 
         // Ensure log directory exists

--- a/src/Etc/Start.php
+++ b/src/Etc/Start.php
@@ -85,7 +85,7 @@ class Start
         ConfigManager::load();
 
         $errorHandler = new ErrorHandler(
-            Environment::isDevelopment(),
+            filter_var(Environment::get('APP_DEBUG', 'false'), FILTER_VALIDATE_BOOLEAN),
             $this->resolveLogPath()
         );
         $errorHandler->register();


### PR DESCRIPTION
## Summary

- **APP_DEBUG now controls exception page detail** — `Start.php` was using `Environment::isDevelopment()` (checks `APP_ENV`) to decide whether to show stack traces, so `APP_DEBUG=false` with `APP_ENV=development` still showed full error output. Now reads `APP_DEBUG` directly via `filter_var`.
- **Linux casing bug fixed in error view paths** — `ErrorHandler` built paths as `$baseDir . '/common/errors/...'` where the actual directory is `src/Common/errors/`. On case-sensitive Linux filesystems this silently fell through to the generic HTML fallback. Paths now use `Application::getInstance()->path('src/Common/errors')`.
- **Static `App\Etc\ErrorHandler` marked `@deprecated`** — the instance-based `App\Etc\Exceptions\ErrorHandler` registered by `Start.php` is the active handler since v2.3.1. The static class is no longer called during bootstrap and will be removed in a future release.
- **Finding 2 (library-mode paths in ConfigManager)** — confirmed already resolved in v2.3.1 (#37), no action needed.

## Test plan

- [ ] Set `APP_ENV=development` and `APP_DEBUG=false` — confirm no stack traces shown, custom error pages render
- [ ] Set `APP_DEBUG=true` — confirm stack traces appear regardless of `APP_ENV`
- [ ] On a Linux host (or case-sensitive mount): trigger a 404 — confirm `src/Common/errors/404.php` loads instead of the generic fallback
- [ ] PHPStan + PHPUnit suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)