### PR TITLE
Harden auth: secure tokens, remove plaintext fallback, CSRF and rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ---
 
+## v2.3.3 - Auth Hardening (2026-06-30)
+
+### Security
+- **Cryptographically secure activation tokens** — `tokenGenerator()` was using `rand()` (predictable, non-CSPRNG). Replaced with `bin2hex(random_bytes(32))` — 64-character hex token, unpredictable and collision-resistant.
+- **Plaintext password fallback removed** — login accepted `hash_equals($storedPassword, $plainPassword)` as a second check after bcrypt. Any user whose stored password was ever plaintext could log in without bcrypt. The fallback is gone; `password_verify()` is the only accepted path.
+- **Open redirect closed** — `$_SESSION['intended_url']` was redirected to without validation. Added `safeIntendedUrl()`: relative paths are allowed as-is; URLs with a host component are only accepted if the host matches `BASE_URL`. All other values fall back to `BASE_URL`.
+- **CSRF protection on login and signup** — both POST handlers now call `Security::validateCsrf()` before processing credentials. Login and signup forms now include a hidden `csrf_token` field via `Security::csrfToken()`.
+- **Rate limiting on login and signup** — login is capped at 5 attempts per IP per 5 minutes; signup at 3 per IP per hour. Both use the existing `Security::rateLimit()` file-based store.
+- **XSS in post-login redirect fixed** — `validateToken()` echoed the redirect URL directly into a `location.href` JS assignment without escaping. Now passes through `htmlspecialchars(..., ENT_QUOTES)`.
+
+---
+
 ## v2.3.2 - Debug Flag & Linux Casing Fixes (2026-06-25)
 
 ### Fixed

--- a/src/Modules/Auth/Controller.php
+++ b/src/Modules/Auth/Controller.php
@@ -31,6 +31,7 @@
 namespace App\Modules\Auth;
 
 use App\Common\Bmvc\BaseView;
+use App\Etc\Security;
 use App\Modules\Mail\MailController;
 use PDO;
 
@@ -66,22 +67,29 @@ class Controller
 
     private function auth()
     {
-        // Fix: Use comparison (===) not assignment (=)
         if (isset($_SESSION["logged"]) && $_SESSION["logged"] === true) {
-            // If already logged in, redirect to intended URL or home
             $intendedUrl = $_SESSION['intended_url'] ?? null;
-            if ($intendedUrl) {
-                unset($_SESSION['intended_url']); // Clear intended URL
-                header("Location: $intendedUrl");
-                exit;  // CRITICAL: Stop execution after redirect
-            } else {
-                $this->url = BASE_URL;
-                header("Location: $this->url");
-                exit;  // CRITICAL: Stop execution after redirect
-            }
+            unset($_SESSION['intended_url']);
+            header("Location: " . $this->safeIntendedUrl($intendedUrl));
+            exit;
         } else {
             $this->login();
         }
+    }
+
+    private function safeIntendedUrl(?string $url): string
+    {
+        if (!$url) {
+            return BASE_URL;
+        }
+        $parsed = parse_url($url);
+        if (isset($parsed['host'])) {
+            $ownHost = parse_url(BASE_URL, PHP_URL_HOST);
+            if ($parsed['host'] !== $ownHost) {
+                return BASE_URL;
+            }
+        }
+        return $url;
     }
 
     private function login()
@@ -103,37 +111,36 @@ class Controller
 
         $users = new Model();
         if ($_POST) {
+            $ip = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
+            if (!Security::rateLimit('login_' . $ip, 5, 300)) {
+                echo "Too many login attempts. Please try again later.";
+                return;
+            }
+            if (!Security::validateCsrf($_POST['csrf_token'] ?? '')) {
+                echo "Invalid request.";
+                return;
+            }
+
             $users->username = $_POST['username'];
-            $plainPassword = (string) ($_POST['password'] ?? '');
-            //$users->tokenSession = $token
+            $plainPassword   = (string) ($_POST['password'] ?? '');
             $stmt            = $users->readUserLogin();
             if ($stmt && ($row = $stmt->fetch(PDO::FETCH_ASSOC))) {
                 $storedPassword = (string) ($row['password'] ?? '');
-                $validPassword = password_verify($plainPassword, $storedPassword)
-                    || hash_equals($storedPassword, $plainPassword);
-
-                if (!$validPassword) {
+                if (!password_verify($plainPassword, $storedPassword)) {
                     echo "Try again!";
                     return;
                 }
 
                 $active = intval($row['state']);
                 if ($active === 1) {
-                    $_SESSION["username"] = $row['username'];
-                    $_SESSION["iduser"]   = $row['id'];
-                    $_SESSION["logged"] = true;           // Legacy compatibility
-                    $_SESSION['authenticated'] = true;     // Middleware compatibility
-                    
-                    // Redirect to intended URL if available, otherwise home
+                    $_SESSION["username"]      = $row['username'];
+                    $_SESSION["iduser"]        = $row['id'];
+                    $_SESSION["logged"]        = true;
+                    $_SESSION['authenticated'] = true;
+
                     $intendedUrl = $_SESSION['intended_url'] ?? null;
-                    if ($intendedUrl) {
-                        $redirectUrl = $intendedUrl;
-                        unset($_SESSION['intended_url']); // Clear intended URL
-                    } else {
-                        $redirectUrl = $this->url;
-                    }
-                    
-                    $this->html->validateToken($redirectUrl);
+                    unset($_SESSION['intended_url']);
+                    $this->html->validateToken($this->safeIntendedUrl($intendedUrl));
                     exit;
                 } else {
                     echo 'You have not activated your account, check your email!';
@@ -183,7 +190,16 @@ class Controller
         $view->endHead();
         $view->startBody($this->title);
         if (isset($_POST["signup"])) {
-            $token          = $this->TokenGenerator(31);
+            $ip = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
+            if (!Security::rateLimit('signup_' . $ip, 3, 3600)) {
+                echo "Too many signup attempts. Please try again later.";
+                return;
+            }
+            if (!Security::validateCsrf($_POST['csrf_token'] ?? '')) {
+                echo "Invalid request.";
+                return;
+            }
+            $token          = $this->tokenGenerator();
             $user->token    = $token;
             $user->name = $_POST["name"];
             $user->username = $_POST['username'];
@@ -210,17 +226,9 @@ class Controller
         $view->endFooter();
     }
 
-    private function tokenGenerator($tokenLength)
+    private function tokenGenerator(): string
     {
-        $char = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-        $token     = '';
-        $n         = 0;
-        while ($n < $tokenLength) {
-            $position = rand(0, strlen($char) - 1);
-            $token .= $char[$position];
-            $n++;
-        }
-        return $token;
+        return bin2hex(random_bytes(32));
     }
 
     private function accountActivation()

--- a/src/Modules/Auth/View.php
+++ b/src/Modules/Auth/View.php
@@ -41,6 +41,7 @@ class View
                 <a href="<?php echo BASE_URL; ?>/signup">Sign up</a>
             </div>
             <form action="" method="post" id="frmLogin" onSubmit="return validate();">
+                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(\App\Etc\Security::csrfToken(), ENT_QUOTES); ?>">
                 <div class="demo-table">
 
                     <div class="form-head">Login</div>
@@ -108,6 +109,7 @@ class View
                 <a href="<?php echo BASE_URL; ?>/auth">Login</a>
             </div>
             <form action="" method="post" id="frmLogin" onSubmit="return validate();">
+                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(\App\Etc\Security::csrfToken(), ENT_QUOTES); ?>">
                 <div class="demo-table">
 
                     <div class="form-head">Login</div>
@@ -200,7 +202,7 @@ class View
     {
     ?>
         <script>
-            location.href = "<?php echo $redirectUrl; ?>";
+            location.href = "<?php echo htmlspecialchars($redirectUrl, ENT_QUOTES); ?>";
         </script>
     <?php
     }


### PR DESCRIPTION
## Summary

- **Cryptographically secure activation tokens** — `rand()` replaced with `bin2hex(random_bytes(32))`
- **Plaintext password fallback removed** — `hash_equals($stored, $plain)` was a backdoor next to bcrypt; now `password_verify()` is the only accepted path
- **Open redirect closed** — `safeIntendedUrl()` validates `intended_url` from session; rejects any host that doesn't match `BASE_URL`
- **CSRF on login and signup** — both POST handlers call `Security::validateCsrf()`; both forms include a hidden `csrf_token` field
- **Rate limiting on login and signup** — 5 attempts/5 min per IP for login; 3 attempts/1 hour per IP for signup
- **XSS in post-login redirect fixed** — `validateToken()` now passes the redirect URL through `htmlspecialchars(..., ENT_QUOTES)` before echoing into JS

## Test plan

- [ ] Login with correct credentials → redirects to home or intended URL (same domain only)
- [ ] Login with wrong password → "Try again!" — no plaintext bypass
- [ ] Login 6 times rapidly → rate limit triggers on 6th attempt
- [ ] Signup with tampered/missing `csrf_token` → "Invalid request."
- [ ] Signup → activation email arrives, token is 64-char hex
- [ ] Set `intended_url` in session to `https://evil.com` → redirected to `BASE_URL` instead
- [ ] PHPStan + PHPUnit suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)