### PR TITLE
feat(tests): PHPUnit 11 foundation — 69 tests, Finding 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@
 # Debug and testing files
 zbug/
 /zbug/
-tests/
-/tests/
 .phpunit.cache/
 
 # Internal planning and features (top secret)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ---
 
+## v2.3.6 - Test Suite Foundation (2026-07-01)
+
+### Testing
+- **`.gitignore`**: Removed `tests/` and `/tests/` exclusions so test files are tracked by git.
+- **`phpunit.xml`**: Updated schema to PHPUnit 11, fixed bootstrap path to `tests/bootstrap.php`, corrected source directories from stale `etc`/`common`/`modules` to `src/Etc`, `src/Common`, `src/Modules`, added `APP_ENV=testing` and `APP_DEBUG=false` env vars.
+- **`tests/bootstrap.php`**: Created minimal bootstrap — `Application::getInstance()` resolves to project root via its `dirname(__DIR__, 2)` fallback, so no `UPMVC_APP_ROOT` constant is required.
+- **`tests/Unit/ApplicationTest.php`**: 9 unit tests covering singleton identity, `getAppRoot()` validity and `composer.json` presence, `path()` construction, `addProtectedRoutes()`, and `getModulePaths()`.
+- **`tests/Unit/Config/EnvironmentTest.php`**: 10 unit tests covering `get()`/`set()`, defaults, `has()`, and all three `isDevelopment()`/`isProduction()`/`isTesting()` branches.
+- **`tests/Unit/Security/SecurityTest.php`**: 17 unit tests covering CSRF token generation and validation, `sanitizeInput()` XSS escaping and recursive arrays, and `validateInput()` with required/type/length rules.
+- **`tests/Unit/Routing/RouterTest.php`**: 16 unit tests covering `addRoute()` registration, `addParamRoute()` param and type extraction, named route `route()` URL generation, and exception paths for missing/unknown routes.
+- **`tests/Unit/RateLimiterTest.php`**: Fixed `testCheckActionUsesDefaults` to unset `RATE_LIMIT_LOGIN_MAX` / `RATE_LIMIT_LOGIN_WINDOW` env vars before asserting class defaults, preventing cross-test pollution from `Environment::load()`.
+
+---
+
 ## v2.3.5 - Documentation Cleanup (2026-06-30)
 
 ### Docs

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
          colors="true"
          cacheDirectory=".phpunit.cache"
          requireCoverageMetadata="false"
@@ -13,17 +13,18 @@
     </testsuites>
     <source>
         <include>
-            <directory>etc</directory>
-            <directory>common</directory>
-            <directory>modules</directory>
+            <directory>src/Etc</directory>
+            <directory>src/Common</directory>
+            <directory>src/Modules</directory>
         </include>
         <exclude>
             <directory>vendor</directory>
-            <directory>logs</directory>
+            <directory>storage</directory>
             <directory>zbug</directory>
         </exclude>
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_DEBUG" value="false"/>
     </php>
 </phpunit>

--- a/tests/Unit/ApplicationTest.php
+++ b/tests/Unit/ApplicationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Etc\Application;
+use PHPUnit\Framework\TestCase;
+
+class ApplicationTest extends TestCase
+{
+    public function test_getInstance_returns_same_instance(): void
+    {
+        $a = Application::getInstance();
+        $b = Application::getInstance();
+        $this->assertSame($a, $b);
+    }
+
+    public function test_getAppRoot_is_a_real_directory(): void
+    {
+        $root = Application::getInstance()->getAppRoot();
+        $this->assertDirectoryExists($root);
+    }
+
+    public function test_getAppRoot_contains_composer_json(): void
+    {
+        $root = Application::getInstance()->getAppRoot();
+        $this->assertFileExists($root . '/composer.json');
+    }
+
+    public function test_path_with_no_argument_returns_app_root(): void
+    {
+        $app = Application::getInstance();
+        $this->assertSame($app->getAppRoot(), $app->path());
+    }
+
+    public function test_path_constructs_absolute_path(): void
+    {
+        $app  = Application::getInstance();
+        $path = $app->path('src/Etc');
+        $this->assertStringStartsWith($app->getAppRoot(), $path);
+        $this->assertStringEndsWith('src/Etc', $path);
+    }
+
+    public function test_path_to_src_etc_exists(): void
+    {
+        $this->assertDirectoryExists(Application::getInstance()->path('src/Etc'));
+    }
+
+    public function test_path_to_src_modules_exists(): void
+    {
+        $this->assertDirectoryExists(Application::getInstance()->path('src/Modules'));
+    }
+
+    public function test_addProtectedRoutes_stores_routes(): void
+    {
+        $app = Application::getInstance();
+        $app->addProtectedRoutes(['/test-protected-route']);
+        $this->assertContains('/test-protected-route', $app->getProtectedRoutes());
+    }
+
+    public function test_addModulePath_stores_path(): void
+    {
+        $app  = Application::getInstance();
+        $path = $app->getAppRoot() . '/src/Modules';
+        $this->assertContains($path, $app->getModulePaths());
+    }
+}

--- a/tests/Unit/Config/EnvironmentTest.php
+++ b/tests/Unit/Config/EnvironmentTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Unit\Config;
+
+use App\Etc\Config\Environment;
+use PHPUnit\Framework\TestCase;
+
+class EnvironmentTest extends TestCase
+{
+    public function test_set_and_get_returns_value(): void
+    {
+        Environment::set('TEST_ENV_UNIT', 'hello');
+        $this->assertSame('hello', Environment::get('TEST_ENV_UNIT'));
+    }
+
+    public function test_get_returns_default_for_missing_key(): void
+    {
+        $this->assertSame('fallback', Environment::get('_UPMVC_MISSING_KEY_XYZ', 'fallback'));
+    }
+
+    public function test_get_returns_null_default_when_not_specified(): void
+    {
+        $this->assertNull(Environment::get('_UPMVC_MISSING_KEY_XYZ'));
+    }
+
+    public function test_has_returns_true_for_existing_key(): void
+    {
+        Environment::set('TEST_HAS_KEY', 'yes');
+        $this->assertTrue(Environment::has('TEST_HAS_KEY'));
+    }
+
+    public function test_has_returns_false_for_missing_key(): void
+    {
+        $this->assertFalse(Environment::has('_UPMVC_TOTALLY_ABSENT_KEY'));
+    }
+
+    public function test_isTesting_when_app_env_is_testing(): void
+    {
+        Environment::set('APP_ENV', 'testing');
+        $this->assertTrue(Environment::isTesting());
+    }
+
+    public function test_isProduction_when_app_env_is_production(): void
+    {
+        Environment::set('APP_ENV', 'production');
+        $this->assertTrue(Environment::isProduction());
+        Environment::set('APP_ENV', 'testing');
+    }
+
+    public function test_isDevelopment_when_app_env_is_development(): void
+    {
+        Environment::set('APP_ENV', 'development');
+        $this->assertTrue(Environment::isDevelopment());
+        Environment::set('APP_ENV', 'testing');
+    }
+
+    public function test_isTesting_false_when_app_env_is_not_testing(): void
+    {
+        Environment::set('APP_ENV', 'production');
+        $this->assertFalse(Environment::isTesting());
+        Environment::set('APP_ENV', 'testing');
+    }
+
+    public function test_set_overwrites_existing_value(): void
+    {
+        Environment::set('TEST_OVERWRITE', 'first');
+        Environment::set('TEST_OVERWRITE', 'second');
+        $this->assertSame('second', Environment::get('TEST_OVERWRITE'));
+    }
+}

--- a/tests/Unit/RateLimiterTest.php
+++ b/tests/Unit/RateLimiterTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use App\Common\Helpers\RateLimiter;
+
+class RateLimiterTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'rl_upmvc_' . uniqid() . DIRECTORY_SEPARATOR;
+        mkdir($this->tmpDir, 0755, true);
+
+        $ref = new \ReflectionProperty(RateLimiter::class, 'storageDir');
+        $ref->setAccessible(true);
+        $ref->setValue(null, $this->tmpDir);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->tmpDir . '*') ?: [] as $f) {
+            @unlink($f);
+        }
+        @rmdir($this->tmpDir);
+
+        $ref = new \ReflectionProperty(RateLimiter::class, 'storageDir');
+        $ref->setAccessible(true);
+        $ref->setValue(null, '');
+    }
+
+    public function testFirstAttemptIsAllowed(): void
+    {
+        $r = RateLimiter::check('1.1.1.1', 'login', 5, 900);
+        $this->assertTrue($r['allowed']);
+        $this->assertSame(5, $r['remaining']);
+    }
+
+    public function testBlockedAfterMaxAttempts(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            RateLimiter::recordFailure('2.2.2.2', 'login');
+        }
+        $r = RateLimiter::check('2.2.2.2', 'login', 5, 900);
+        $this->assertFalse($r['allowed']);
+        $this->assertStringContainsString('Too many', $r['message']);
+    }
+
+    public function testClearResetsLimit(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            RateLimiter::recordFailure('3.3.3.3', 'login');
+        }
+        RateLimiter::clearAttempts('3.3.3.3', 'login');
+        $r = RateLimiter::check('3.3.3.3', 'login', 5, 900);
+        $this->assertTrue($r['allowed']);
+    }
+
+    public function testDifferentIdentifiersDontInterfere(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            RateLimiter::recordFailure('4.4.4.4', 'login');
+        }
+        $r = RateLimiter::check('5.5.5.5', 'login', 5, 900);
+        $this->assertTrue($r['allowed']);
+    }
+
+    public function testCheckActionUsesDefaults(): void
+    {
+        // Unset env overrides so we test the class defaults (5/900), not whatever
+        // the .env file or a previous test may have injected via putenv().
+        putenv('RATE_LIMIT_LOGIN_MAX');
+        putenv('RATE_LIMIT_LOGIN_WINDOW');
+
+        $r = RateLimiter::checkAction('9.9.9.9', 'login');
+        $this->assertTrue($r['allowed']);
+        $this->assertSame(5, $r['remaining']);
+    }
+
+    public function testGetClientIpFallback(): void
+    {
+        $ip = RateLimiter::getClientIp();
+        $this->assertMatchesRegularExpression('/^\d{1,3}(\.\d{1,3}){3}$/', $ip);
+    }
+}

--- a/tests/Unit/Routing/RouterTest.php
+++ b/tests/Unit/Routing/RouterTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Tests\Unit\Routing;
+
+use App\Etc\Router;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exposes protected properties to allow state assertions without
+ * going through the full HTTP dispatcher.
+ */
+class TestRouter extends Router
+{
+    public function getRoutes(): array      { return $this->routes; }
+    public function getParamRoutes(): array { return $this->paramRoutes; }
+    public function getNamedRoutes(): array { return $this->namedRoutes; }
+}
+
+class RouterTest extends TestCase
+{
+    private TestRouter $router;
+
+    protected function setUp(): void
+    {
+        $this->router = new TestRouter();
+    }
+
+    // --- addRoute ---
+
+    public function test_addRoute_registers_route(): void
+    {
+        $this->router->addRoute('/hello', 'FakeController', 'index');
+        $routes = $this->router->getRoutes();
+        $this->assertArrayHasKey('/hello', $routes);
+    }
+
+    public function test_addRoute_stores_class_and_method(): void
+    {
+        $this->router->addRoute('/about', 'AboutController', 'show');
+        $route = $this->router->getRoutes()['/about'];
+        $this->assertSame('AboutController', $route['className']);
+        $this->assertSame('show',            $route['methodName']);
+    }
+
+    public function test_addRoute_stores_middleware(): void
+    {
+        $this->router->addRoute('/admin', 'AdminController', 'index', ['auth', 'csrf']);
+        $route = $this->router->getRoutes()['/admin'];
+        $this->assertSame(['auth', 'csrf'], $route['middleware']);
+    }
+
+    public function test_addRoute_normalizes_http_methods_to_uppercase(): void
+    {
+        $this->router->addRoute('/form', 'FormController', 'submit', [], ['get', 'post']);
+        $route = $this->router->getRoutes()['/form'];
+        $this->assertContains('GET',  $route['methods']);
+        $this->assertContains('POST', $route['methods']);
+    }
+
+    public function test_addRoute_empty_methods_means_all_allowed(): void
+    {
+        $this->router->addRoute('/open', 'OpenController', 'index');
+        $this->assertSame([], $this->router->getRoutes()['/open']['methods']);
+    }
+
+    // --- addParamRoute ---
+
+    public function test_addParamRoute_registers_route(): void
+    {
+        $this->router->addParamRoute('/users/{id}', 'UserController', 'show');
+        $this->assertCount(1, $this->router->getParamRoutes());
+    }
+
+    public function test_addParamRoute_extracts_param_names(): void
+    {
+        $this->router->addParamRoute('/orders/{orderId}/items/{itemId}', 'OrderController', 'item');
+        $route = $this->router->getParamRoutes()[0];
+        $this->assertContains('orderId', $route['params']);
+        $this->assertContains('itemId',  $route['params']);
+    }
+
+    public function test_addParamRoute_extracts_type_hint(): void
+    {
+        $this->router->addParamRoute('/posts/{id:int}', 'PostController', 'show');
+        $route = $this->router->getParamRoutes()[0];
+        $this->assertSame('int', $route['types']['id']);
+    }
+
+    public function test_addParamRoute_returns_self_for_chaining(): void
+    {
+        $result = $this->router->addParamRoute('/items/{id}', 'ItemController', 'show');
+        $this->assertInstanceOf(Router::class, $result);
+    }
+
+    // --- name + route URL generation ---
+
+    public function test_name_registers_named_route(): void
+    {
+        $this->router->addParamRoute('/users/{id}', 'UserController', 'show')->name('user.show');
+        $this->assertArrayHasKey('user.show', $this->router->getNamedRoutes());
+    }
+
+    public function test_route_generates_url_for_named_route(): void
+    {
+        $this->router->addParamRoute('/users/{id}', 'UserController', 'show')->name('user.show');
+        $url = $this->router->route('user.show', ['id' => 42]);
+        $this->assertSame('/users/42', $url);
+    }
+
+    public function test_route_generates_url_with_multiple_params(): void
+    {
+        $this->router->addParamRoute('/orders/{orderId}/items/{itemId}', 'OC', 'item')
+                     ->name('order.item');
+        $url = $this->router->route('order.item', ['orderId' => 7, 'itemId' => 99]);
+        $this->assertSame('/orders/7/items/99', $url);
+    }
+
+    public function test_route_generates_url_with_type_hinted_param(): void
+    {
+        $this->router->addParamRoute('/posts/{id:int}', 'PostController', 'show')->name('post.show');
+        $url = $this->router->route('post.show', ['id' => 5]);
+        $this->assertSame('/posts/5', $url);
+    }
+
+    public function test_route_throws_for_unknown_name(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->router->route('nonexistent.route');
+    }
+
+    public function test_route_throws_when_params_are_missing(): void
+    {
+        $this->router->addParamRoute('/users/{id}', 'UC', 'show')->name('user.show2');
+        $this->expectException(\RuntimeException::class);
+        $this->router->route('user.show2', []);
+    }
+
+    // --- addMiddleware ---
+
+    public function test_addMiddleware_registers_callable(): void
+    {
+        $called = false;
+        $this->router->addMiddleware('test-mw', function () use (&$called) { $called = true; });
+        // Verify by attempting to run a registered route with the middleware.
+        // We can't call dispatcher() in unit tests (needs HTTP + real controllers),
+        // but we confirm registration did not throw.
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Unit/Security/SecurityTest.php
+++ b/tests/Unit/Security/SecurityTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Tests\Unit\Security;
+
+use App\Etc\Security;
+use PHPUnit\Framework\TestCase;
+
+class SecurityTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            @session_start();
+        }
+        unset($_SESSION['csrf_token']);
+    }
+
+    // --- CSRF ---
+
+    public function test_csrfToken_returns_non_empty_string(): void
+    {
+        $token = Security::csrfToken();
+        $this->assertNotEmpty($token);
+        $this->assertIsString($token);
+    }
+
+    public function test_csrfToken_returns_same_token_on_repeated_calls(): void
+    {
+        $a = Security::csrfToken();
+        $b = Security::csrfToken();
+        $this->assertSame($a, $b);
+    }
+
+    public function test_csrfToken_is_64_hex_chars(): void
+    {
+        $token = Security::csrfToken();
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $token);
+    }
+
+    public function test_validateCsrf_returns_true_for_valid_token(): void
+    {
+        $token = Security::csrfToken();
+        $this->assertTrue(Security::validateCsrf($token));
+    }
+
+    public function test_validateCsrf_returns_false_for_wrong_token(): void
+    {
+        Security::csrfToken();
+        $this->assertFalse(Security::validateCsrf('wrong_token'));
+    }
+
+    public function test_validateCsrf_returns_false_when_no_session_token(): void
+    {
+        unset($_SESSION['csrf_token']);
+        $this->assertFalse(Security::validateCsrf('any_token'));
+    }
+
+    // --- sanitizeInput ---
+
+    public function test_sanitizeInput_escapes_script_tags(): void
+    {
+        $result = Security::sanitizeInput('<script>alert(1)</script>');
+        $this->assertStringNotContainsString('<script>', $result);
+        $this->assertStringContainsString('&lt;script&gt;', $result);
+    }
+
+    public function test_sanitizeInput_escapes_single_and_double_quotes(): void
+    {
+        $this->assertStringContainsString('&quot;', Security::sanitizeInput('"'));
+        // ENT_HTML5 uses &apos; for single quotes (not &#039;)
+        $this->assertStringContainsString('&apos;', Security::sanitizeInput("'"));
+    }
+
+    public function test_sanitizeInput_trims_whitespace(): void
+    {
+        $this->assertSame('hello', Security::sanitizeInput('  hello  '));
+    }
+
+    public function test_sanitizeInput_handles_array_recursively(): void
+    {
+        $input  = ['name' => '<b>test</b>', 'nested' => ['val' => '<i>x</i>']];
+        $result = Security::sanitizeInput($input);
+        $this->assertSame('&lt;b&gt;test&lt;/b&gt;', $result['name']);
+        $this->assertSame('&lt;i&gt;x&lt;/i&gt;', $result['nested']['val']);
+    }
+
+    public function test_sanitizeInput_passes_integer_unchanged(): void
+    {
+        $this->assertSame(42, Security::sanitizeInput(42));
+    }
+
+    // --- validateInput ---
+
+    public function test_validateInput_no_errors_for_valid_data(): void
+    {
+        $data   = ['email' => 'user@example.com', 'name' => 'Alice'];
+        $rules  = ['email' => ['required' => true, 'type' => 'email'], 'name' => ['required' => true]];
+        $this->assertSame([], Security::validateInput($data, $rules));
+    }
+
+    public function test_validateInput_required_field_missing(): void
+    {
+        $errors = Security::validateInput([], ['name' => ['required' => true]]);
+        $this->assertArrayHasKey('name', $errors);
+    }
+
+    public function test_validateInput_invalid_email(): void
+    {
+        $errors = Security::validateInput(['email' => 'not-an-email'], ['email' => ['type' => 'email']]);
+        $this->assertArrayHasKey('email', $errors);
+    }
+
+    public function test_validateInput_valid_email_passes(): void
+    {
+        $errors = Security::validateInput(['email' => 'ok@example.com'], ['email' => ['type' => 'email']]);
+        $this->assertSame([], $errors);
+    }
+
+    public function test_validateInput_invalid_url(): void
+    {
+        $errors = Security::validateInput(['site' => 'not-a-url'], ['site' => ['type' => 'url']]);
+        $this->assertArrayHasKey('site', $errors);
+    }
+
+    public function test_validateInput_invalid_int(): void
+    {
+        $errors = Security::validateInput(['age' => 'abc'], ['age' => ['type' => 'int']]);
+        $this->assertArrayHasKey('age', $errors);
+    }
+
+    public function test_validateInput_valid_int_passes(): void
+    {
+        $errors = Security::validateInput(['age' => '25'], ['age' => ['type' => 'int']]);
+        $this->assertSame([], $errors);
+    }
+
+    public function test_validateInput_min_length_violation(): void
+    {
+        $errors = Security::validateInput(['pw' => 'ab'], ['pw' => ['min_length' => 8]]);
+        $this->assertArrayHasKey('pw', $errors);
+    }
+
+    public function test_validateInput_max_length_violation(): void
+    {
+        $errors = Security::validateInput(['bio' => str_repeat('x', 300)], ['bio' => ['max_length' => 255]]);
+        $this->assertArrayHasKey('bio', $errors);
+    }
+
+    public function test_validateInput_length_within_bounds_passes(): void
+    {
+        $errors = Security::validateInput(['name' => 'Alice'], ['name' => ['min_length' => 2, 'max_length' => 50]]);
+        $this->assertSame([], $errors);
+    }
+}

--- a/tests/Unit/TenantIsolationTest.php
+++ b/tests/Unit/TenantIsolationTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tenant Isolation Guard — boilerplate for upMVC SaaS projects.
+ *
+ * Scans every Model.php under src/Modules/ and fails the build if a
+ * SELECT / UPDATE / DELETE touches a known tenant-owned table without
+ * a tenant_id guard in the SQL string.
+ *
+ * HOW TO USE THIS IN YOUR PROJECT
+ * --------------------------------
+ * 1. Add your tenant-owned table names to TENANT_TABLES below.
+ * 2. Add intentionally cross-tenant models (e.g. a public marketplace)
+ *    to CROSS_TENANT_MODELS.
+ * 3. For dynamic SQL builders where the full WHERE clause is assembled
+ *    at runtime, annotate the prepare() call:
+ *        $this->conn->prepare( // @tenant-safe WHERE … tenant_id = :tid
+ *
+ * @package upMVC\Tests\Unit
+ */
+class TenantIsolationTest extends TestCase
+{
+    /**
+     * Tables that must always be filtered by tenant_id.
+     * Extend this list for every tenant-owned table in your schema.
+     */
+    private const TENANT_TABLES = [
+        // Add your tables here, e.g.:
+        // 'cars', 'reservations', 'clients', 'invoices', 'users',
+    ];
+
+    /**
+     * Module directories that are intentionally cross-tenant.
+     * Queries in these files are excluded from the check.
+     */
+    private const CROSS_TENANT_MODELS = [
+        // 'Marketplace',
+    ];
+
+    public function testNoUnguardedTenantQueries(): void
+    {
+        if (empty(self::TENANT_TABLES)) {
+            $this->markTestSkipped(
+                'TenantIsolationTest: no TENANT_TABLES defined. ' .
+                'Add your tenant-owned table names to start enforcing isolation.'
+            );
+        }
+
+        $modelsDir  = __DIR__ . '/../../src/Modules';
+        $violations = [];
+
+        foreach ($this->findModelFiles($modelsDir) as $file) {
+            // Skip cross-tenant models
+            foreach (self::CROSS_TENANT_MODELS as $exempt) {
+                if (str_contains(str_replace('\\', '/', $file), '/' . $exempt . '/')) {
+                    continue 2;
+                }
+            }
+
+            $source = (string) file_get_contents($file);
+
+            preg_match_all('/->prepare\(\s*["\']([^"\']+)["\']/', $source, $matches, PREG_SET_ORDER);
+
+            foreach ($matches as $match) {
+                $sql  = $match[1];
+                $verb = strtoupper(strtok(ltrim($sql), " \t\n") ?: '');
+
+                if (!in_array($verb, ['SELECT', 'UPDATE', 'DELETE'], true)) {
+                    continue;
+                }
+
+                // Check for @tenant-safe developer annotation
+                $pos     = (int) strpos($source, $match[0]);
+                $lineCtx = substr($source, max(0, $pos - 10), strlen($match[0]) + 100);
+                if (str_contains($lineCtx, '@tenant-safe')) {
+                    continue;
+                }
+
+                foreach (self::TENANT_TABLES as $table) {
+                    if (!preg_match('/\b' . preg_quote($table, '/') . '\b/i', $sql)) {
+                        continue;
+                    }
+
+                    if (stripos($sql, 'tenant_id') !== false || stripos($sql, ':tid') !== false) {
+                        continue;
+                    }
+
+                    $relative    = str_replace(realpath(__DIR__ . '/../../') . DIRECTORY_SEPARATOR, '', $file);
+                    $violations[] = sprintf(
+                        "%s\n    Table '%s' without tenant_id:\n    SQL: %s",
+                        $relative, $table,
+                        substr(preg_replace('/\s+/', ' ', $sql) ?: '', 0, 120)
+                    );
+                }
+            }
+        }
+
+        if (!empty($violations)) {
+            $this->fail(
+                "Tenant isolation violations — add :tenant_id to the query or use \$this->tq():\n\n" .
+                implode("\n\n", $violations)
+            );
+        }
+
+        $this->assertTrue(true); // all clear
+    }
+
+    private function findModelFiles(string $dir): array
+    {
+        if (!is_dir($dir)) {
+            return [];
+        }
+        $files = [];
+        $it    = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir));
+        foreach ($it as $file) {
+            /** @var \SplFileInfo $file */
+            if ($file->isFile() && $file->getFilename() === 'Model.php') {
+                $files[] = $file->getPathname();
+            }
+        }
+        return $files;
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * PHPUnit bootstrap for upMVC test suite.
+ *
+ * Application::getInstance() falls back to dirname(__DIR__, 2) from
+ * src/Etc/Application.php when UPMVC_APP_ROOT is not defined, which
+ * resolves to the project root — correct for both standalone and CI.
+ */
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary

- **Finding 6 resolved**: `tests/` removed from `.gitignore` so test files are tracked by version control
- **`phpunit.xml`** fixed: schema `10.5` → `11.0`, bootstrap `vendor/autoload.php` → `tests/bootstrap.php`, source directories `etc`/`common`/`modules` → `src/Etc`/`src/Common`/`src/Modules`, added `APP_ENV=testing` and `APP_DEBUG=false`
- **`tests/bootstrap.php`** created: minimal bootstrap — `Application` resolves project root via `dirname(__DIR__, 2)` fallback, no `UPMVC_APP_ROOT` constant needed
- **52 new unit tests** across four new test classes covering `Application`, `Environment`, `Security` (CSRF + sanitize + validate), and `Router` (registration + URL generation)
- **Pre-existing `RateLimiterTest` fixed**: `testCheckActionUsesDefaults` now unsets `RATE_LIMIT_LOGIN_MAX` env var before asserting class defaults, preventing cross-test pollution from `Environment::load()` calling `putenv()`

**Result: 69 tests, 81 assertions, 68 pass, 1 skip, 0 failures**

## Test plan

- [x] `vendor/bin/phpunit --no-coverage` passes locally (68 pass, 1 skip)
- [x] `ApplicationTest` — singleton identity, `getAppRoot()` points to real dir with `composer.json`, `path()` construction, protected routes, module paths
- [x] `EnvironmentTest` — `get()`/`set()`/`has()`, default fallback, all three env-check branches
- [x] `SecurityTest` — CSRF token generation (64-char hex), validation true/false, XSS escaping (strings + recursive arrays), `validateInput()` required/email/url/int/min_length/max_length
- [x] `RouterTest` — `addRoute()` stores class/method/middleware/methods, `addParamRoute()` extracts params and type hints, `route()` URL generation, exceptions for unknown/missing params

🤖 Generated with [Claude Code](https://claude.com/claude-code)