### PR TITLE
feat(agent): portable AI knowledge pack and upmvc-next CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ vault/
 /vault/**
 private-vault/
 
+# Agent CLI generated output (ephemeral)
+docs/agent/generated/
+
 # Logs
 logs/
 *.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# upMVC — Agent context
+
+You are working inside an **upMVC** PHP project. Do not ask the user to explain the framework.
+
+## Load first
+
+- `docs/AGENT_PACK.md` — full usage guide
+- `docs/agent/upmvc-knowledge.json` — paths, bootstrap, config, modules, packages
+- `docs/agent/upmvc-rules.json` — must/never constraints
+- `docs/agent/upmvc-workflows.json` — match user intent to a recipe
+
+If `bitshost/upmvc-saas-pack` is installed or `src/Etc/packages.php` registers `SaasServiceProvider`, also load:
+
+- `docs/agent/upmvc-saas-pack.json`
+
+## Behavior
+
+1. User states what they want — you are already in the project.
+2. Run or simulate `php src/Tools/upmvc-next.php` for project scan + prompt package.
+3. Output a **plan** (JSON) before multi-file edits.
+4. Follow `upmvc-rules.json` strictly; scope SaaS queries with `tenant_id`.
+
+## Docs
+
+- `docs/MODULE_PHILOSOPHY.md`
+- `docs/CORE_AREAS_AND_CONFIGURATION.md`
+- `docs/agent/README.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Agent pack (AiAgent branch)
+- **`docs/AGENT_PACK.md`** — Full guide: what the pack is, how to use it, how to update rules and workflows
+- **`docs/agent/`** — Portable JSON knowledge pack: `upmvc-knowledge.json`, `upmvc-rules.json`, `upmvc-workflows.json`, `upmvc-saas-pack.json`
+- **`src/Tools/upmvc-next.php`** — Interactive CLI: scan project, ask what you want, output `docs/agent/generated/last-prompt.md`
+- **`AGENTS.md`** — Root pointer for Cursor/cloud agents
+- **`tests/Unit/Tools/`** — Minimal tests for agent JSON pack and CLI smoke checks
+- **Accuracy pass (v1.0.1)** — JSON pack aligned to v2.3.6: addRoute middleware syntax, InitModsImproved, optional packages.php, SaaS JWT vs tenant middleware, removed stale Billing/tq()/->middleware() references
+- **Review fixes** — `upmvc-saas-pack.json` optional at CLI load; stable module sort; test tearDown; no hardcoded pack version in tests
+- **`README.md`**, **`docs/DOCUMENTATION-INDEX.md`** — Linked from quick navigation
+
 ---
 
 ## v2.3.6 - Test Suite Foundation (2026-07-01)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ upMVC excels at integrating **pre-built JavaScript applications** from any frame
 ### **🔐 Security & Authentication:**
 - **[JWT Authentication Guide](docs/JWT_AUTHENTICATION.md)** — Opt-in JWT support: issue tokens with `JwtService`, protect API routes with `['jwt']` middleware, refresh token flow. Sessions are unaffected — JWT is an additional option for APIs and SPAs.
 
+### **🤖 AI Agent Pack:**
+- **[Agent Pack Guide](docs/AGENT_PACK.md)** — Portable JSON knowledge + `upmvc-next.php` CLI: drop in, say what you want, get a ready agent prompt (Cursor, Claude, local LLMs)
+
 ### **🏗 Architecture & Philosophy:**
 - **[🎨 Pure PHP Philosophy](docs/PHILOSOPHY_PURE_PHP.md)** - The upMVC NoFramework approach
 - **[🧩 Module Philosophy](docs/MODULE_PHILOSOPHY.md)** - Modules as reference implementations
@@ -337,6 +340,17 @@ Affected components:
 
 Exit codes: `0` success, `1` failure, `2` unknown command.
 
+
+## 🤖 AI Agent Pack
+
+Use the agent pack when working with Cursor or other AI assistants on upMVC projects. It scans your repo, asks what you want, and outputs a context-rich prompt — no framework lecture required.
+
+```bash
+php src/Tools/upmvc-next.php
+php src/Tools/upmvc-next.php --goal "Add a contact form module" --stdout
+```
+
+Knowledge files live in `docs/agent/` (`upmvc-knowledge.json`, `upmvc-rules.json`, `upmvc-workflows.json`). Full guide: **[docs/AGENT_PACK.md](docs/AGENT_PACK.md)**.
 
 ## ⚙️ Configuration
 

--- a/docs/AGENT_PACK.md
+++ b/docs/AGENT_PACK.md
@@ -1,0 +1,226 @@
+# upMVC Agent Pack
+
+Portable knowledge for AI coding assistants (Cursor, Claude, Gemini, local LLMs). The goal: **drop the user in the middle of the house** — they state what they want; the agent already knows upMVC paths, rules, and workflows.
+
+This complements Cursor (or any IDE agent). It does not replace it.
+
+---
+
+## What it is
+
+The agent pack is a small set of **versioned JSON files** plus a thin **CLI script** that:
+
+1. Scans your project (modules, `.env`, `packages.php`, SaaS pack detection)
+2. Asks what you want to build (one question)
+3. Outputs a ready-to-paste prompt with context, workflow steps, and rule summaries
+
+```
+docs/agent/
+  upmvc-knowledge.json   ← framework facts (bootstrap, config, modules, packages)
+  upmvc-rules.json       ← hard must / never rules
+  upmvc-workflows.json   ← recipes (create module, SaaS CRUD, config audit, …)
+  upmvc-saas-pack.json   ← SaaS pack architecture (when applicable)
+  generated/             ← ephemeral CLI output (gitignored)
+
+src/Tools/upmvc-next.php  ← interactive prompt builder
+AGENTS.md                 ← entry point for Cursor / cloud agents
+```
+
+---
+
+## Quick start
+
+From the project root:
+
+```bash
+php src/Tools/upmvc-next.php
+```
+
+You will see a short project snapshot, then:
+
+```
+What do you want to do?
+  • Add a contact form module
+  • Bookings API for my SaaS tenants
+  • Audit why my .env settings are ignored
+```
+
+The script writes:
+
+- `docs/agent/generated/last-prompt.md` — paste into your agent chat
+- `docs/agent/generated/last-session.json` — machine-readable scan + workflow match
+
+### Non-interactive
+
+```bash
+php src/Tools/upmvc-next.php --goal "Add a bookings API for my SaaS"
+php src/Tools/upmvc-next.php --goal "Audit config wiring" --stdout
+```
+
+---
+
+## Use in Cursor
+
+### Option A — One-shot (simplest)
+
+1. Run `php src/Tools/upmvc-next.php`
+2. Open `docs/agent/generated/last-prompt.md`
+3. Paste into a new Cursor chat
+
+### Option B — Project rule (persistent)
+
+Create or extend a Cursor rule that tells the agent to load:
+
+- `docs/agent/upmvc-knowledge.json`
+- `docs/agent/upmvc-rules.json`
+
+Add `upmvc-saas-pack.json` only when your project uses the SaaS pack. The CLI treats this file as **optional** — standalone installs need only the three core JSON files.
+
+### Option C — `AGENTS.md` (cloud agents)
+
+Root [`AGENTS.md`](../AGENTS.md) points agents at this pack automatically when supported.
+
+---
+
+## Use in other agents
+
+Import the JSON files into system context, a skill, or a RAG index:
+
+| File | When to load |
+|------|----------------|
+| `upmvc-knowledge.json` | Always |
+| `upmvc-rules.json` | Always |
+| `upmvc-workflows.json` | When planning multi-step work |
+| `upmvc-saas-pack.json` | Only for upMVC-SaaS / `bitshost/upmvc-saas-pack` projects |
+
+Always pair **knowledge + rules**. The agent should **plan first** (JSON plan with files and risks) before editing multiple files.
+
+---
+
+## File reference
+
+### `upmvc-knowledge.json`
+
+Framework facts an agent should not re-discover each session:
+
+- Bootstrap flow (`public/index.php` → `Start.php` → routing)
+- Paths (`src/Etc/.env` — canonical runtime path via `Environment::load()`, not project-root `.env`)
+- Config access (`Environment::get()`, `ConfigManager::get()`)
+- Module structure and auto-discovery
+- Package/provider system (`Application::addModulePath()`, `registerProviders()`)
+- Middleware names and behavior
+
+Bump `meta.version` when you change structure or add major sections.
+
+### `upmvc-rules.json`
+
+Hard constraints — **must**, **never**, **saas_must**, **prefer**:
+
+```json
+{
+  "must": [
+    "Read config with Environment::get() or ConfigManager::get() — never $_ENV for .env values"
+  ],
+  "never": [
+    "Hardcode credentials, API keys, or secrets in PHP files"
+  ]
+}
+```
+
+These are the guardrails. Keep the list short and actionable.
+
+### `upmvc-workflows.json`
+
+Recipes keyed by intent (`create_module`, `saas_domain_module`, `config_audit`, …). Each workflow has `intent_keywords` and ordered `steps`. The CLI matches user goals to workflows by keyword overlap.
+
+### `upmvc-saas-pack.json`
+
+SaaS-specific knowledge: three-layer architecture (kernel + pack + starter), `jwt` / `tenant` / `feature:*` middleware, `tenant_id` scoping, `SaasApiController` patterns. Load only when the SaaS pack is present.
+
+---
+
+## How to update rules
+
+### Add a new must/never rule
+
+1. Edit `docs/agent/upmvc-rules.json`
+2. Add one clear sentence to `must`, `never`, or `saas_must`
+3. If the rule needs context (why it exists), add a short note in `docs/AGENT_PACK.md` or the relevant framework doc — keep JSON entries terse
+4. Run tests: `vendor\bin\phpunit tests\Unit\Tools`
+5. Bump `meta.version` in `upmvc-rules.json` (patch: `1.0.0` → `1.0.1`)
+
+**Good rule:** actionable, verifiable — *"Use PDO prepared statements for all SQL"*
+
+**Bad rule:** vague — *"Write good code"*
+
+### Add a new workflow
+
+1. Edit `docs/agent/upmvc-workflows.json`
+2. Add a workflow block:
+
+```json
+"my_workflow": {
+  "intent_keywords": ["keyword1", "keyword2"],
+  "steps": [
+    "Step one",
+    "Step two"
+  ],
+  "files_touched": ["src/Modules/{Name}/Routes/Routes.php"]
+}
+```
+
+3. Test matching: `php src/Tools/upmvc-next.php --goal "your keyword phrase" --stdout`
+4. Confirm `Workflow: \`my_workflow\`` appears in output
+
+### Update framework facts
+
+When bootstrap, config keys, or package APIs change in upMVC core:
+
+1. Update `upmvc-knowledge.json` (and `upmvc-saas-pack.json` if SaaS-related)
+2. Bump `meta.version`
+3. Update this page if user-facing usage changed
+
+### Team-only notes
+
+Internal planning may live in `private-vault/` (gitignored). **Never** put credentials or secrets into the agent pack. Distill architecture lessons into the public JSON files.
+
+---
+
+## Standalone vs SaaS
+
+| Signal | Mode |
+|--------|------|
+| No `bitshost/upmvc-saas-pack` in `composer.json` | Standalone — load 3 JSON files |
+| `packages.php` registers `SaasServiceProvider` | SaaS — also load `upmvc-saas-pack.json` |
+
+The CLI detects this automatically and includes SaaS rules in the generated prompt.
+
+---
+
+## Testing
+
+Minimal smoke tests live in `tests/Unit/Tools/`:
+
+```bash
+vendor\bin\phpunit tests\Unit\Tools
+```
+
+Covers: JSON validity, `AGENTS.md` links, CLI exit codes, workflow routing, generated file output.
+
+---
+
+## Philosophy
+
+- **No startup lecture** — user says what they want; agent already knows the house layout
+- **JSON over custom platform** — portable, versionable, model-agnostic
+- **Plan before write** — multi-file changes need an approved JSON plan first
+- **Complement the IDE** — Cursor still edits code; this pack supplies upMVC-native context
+
+---
+
+## Related docs
+
+- [Module Philosophy](MODULE_PHILOSOPHY.md)
+- [Core Areas and Configuration](CORE_AREAS_AND_CONFIGURATION.md)
+- [JWT Authentication](JWT_AUTHENTICATION.md)
+- [docs/agent/README.md](agent/README.md) — folder quick reference

--- a/docs/CORE_AREAS_AND_CONFIGURATION.md
+++ b/docs/CORE_AREAS_AND_CONFIGURATION.md
@@ -185,6 +185,7 @@ Key items:
 - `ModuleGeneratorEnhanced/ModuleGeneratorEnhanced.php` – generates full modules (controllers, models, views, routes) that plug into `InitModsImproved`.
 - `modulegenerator/`, `crudgenerator/`, `createmodule/` – earlier generators kept for backwards compatibility and experimentation.
 - `cache-cli.php` – CLI helper for cache operations.
+- `upmvc-next.php` – builds AI agent prompts from `docs/agent/` JSON pack ([Agent Pack Guide](../AGENT_PACK.md)).
 
 Usage:
 - Run via PHP CLI from project root, e.g.:

--- a/docs/DOCUMENTATION-INDEX.md
+++ b/docs/DOCUMENTATION-INDEX.md
@@ -9,6 +9,7 @@
 | **[🏗 CORE_AREAS_AND_CONFIGURATION.md](CORE_AREAS_AND_CONFIGURATION.md)** | Understand src/Etc, Modules, Tools, Common | 15-30 min | ✅ Ready |
 | **[📘 HOW-TO-GUIDE.md](HOW-TO-GUIDE.md)** | Complete development guide | 30-60 min | ✅ Ready |
 | **[🔐 JWT_AUTHENTICATION.md](JWT_AUTHENTICATION.md)** | JWT auth — issue tokens, protect routes, refresh flow | 15 min | ✅ Ready |
+| **[🤖 AGENT_PACK.md](AGENT_PACK.md)** | AI agent knowledge pack — `upmvc-next.php`, rules, workflows | 10 min | ✅ Ready |
 | **[❓ FAQ.md](FAQ.md)** | Common questions & troubleshooting | As needed | ✅ Ready |
 
 ---

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -1,0 +1,25 @@
+# Agent pack files (this folder)
+
+**Full guide:** [../AGENT_PACK.md](../AGENT_PACK.md) — what it is, how to use it, how to update rules.
+
+## Quick start
+
+```bash
+php src/Tools/upmvc-next.php
+```
+
+Paste `generated/last-prompt.md` into your agent chat.
+
+## Files here
+
+| File | Purpose |
+|------|---------|
+| `upmvc-knowledge.json` | Framework facts |
+| `upmvc-rules.json` | Must / never rules |
+| `upmvc-workflows.json` | Intent → recipe mapping |
+| `upmvc-saas-pack.json` | SaaS pack (optional file — include only for SaaS projects) |
+| `generated/` | CLI output (gitignored) |
+
+## Updating rules
+
+Edit `upmvc-rules.json` or `upmvc-workflows.json`, bump `meta.version`, run `vendor\bin\phpunit tests\Unit\Tools`. See the [main guide](../AGENT_PACK.md#how-to-update-rules).

--- a/docs/agent/upmvc-knowledge.json
+++ b/docs/agent/upmvc-knowledge.json
@@ -1,0 +1,185 @@
+{
+  "meta": {
+    "name": "upMVC Agent Knowledge Pack",
+    "version": "1.0.1",
+    "verified_against": "upMVC v2.3.6",
+    "framework": "upMVC",
+    "php_minimum": "8.1",
+    "purpose": "Portable startup context for any AI agent working on upMVC or upMVC-SaaS projects",
+    "usage": "Load this file at session start together with upmvc-rules.json. Do not ask the user to explain framework basics."
+  },
+  "philosophy": {
+    "summary": "Pure PHP MVC. Modules are optional reference implementations. Minimal core, explicit control, no ORM required.",
+    "principles": [
+      "Modules auto-discovered — drop folder in src/Modules, routes register automatically",
+      "PDO prepared statements — no magic query builder required",
+      "Config from .env via Environment::get() and ConfigManager::get()",
+      "Framework stays out of the way — app-specific patterns belong in app layer, not core"
+    ],
+    "docs": [
+      "docs/MODULE_PHILOSOPHY.md",
+      "docs/PHILOSOPHY_PURE_PHP.md",
+      "docs/CORE_AREAS_AND_CONFIGURATION.md",
+      "docs/CONFIGURATION_FALLBACKS.md"
+    ]
+  },
+  "paths": {
+    "app_root": "UPMVC_APP_ROOT or project root (dirname above src/)",
+    "entry": "public/index.php",
+    "env_file": "src/Etc/.env",
+    "env_file_note": "Copy from src/Etc/.env.example — canonical path loaded by Environment::load()",
+    "env_example": "src/Etc/.env.example",
+    "core": "src/Etc/",
+    "modules": "src/Modules/",
+    "common": "src/Common/",
+    "logs": "src/logs/",
+    "storage": "storage/",
+    "cache": "storage/cache/",
+    "admin_route_cache": "src/Etc/storage/cache/admin_routes.php",
+    "packages_registry": "src/Etc/packages.php (optional — create when using Composer packages; upMVC-SaaS ships one)",
+    "custom_routes": "src/Etc/custom-routes.php",
+    "module_structure": {
+      "controller": "src/Modules/{Name}/Controller.php",
+      "model": "src/Modules/{Name}/Model.php",
+      "view": "src/Modules/{Name}/View.php",
+      "routes": "src/Modules/{Name}/Routes/Routes.php",
+      "config_metadata": "src/Modules/{Name}/etc/config.php"
+    },
+    "note_module_etc_config": "Module etc/config.php files are generator metadata — not loaded by runtime unless you wire them yourself"
+  },
+  "bootstrap": {
+    "flow": [
+      "public/index.php defines UPMVC_APP_ROOT and loads vendor/autoload.php",
+      "new Start() → ConfigManager::load(), ErrorHandler (APP_DEBUG), request init",
+      "Start::upMVC() → Router, Application::registerProviders(), global middleware, named middleware",
+      "Application::bootProviders($router), then App\\Etc\\Routes::startRoutes()"
+    ],
+    "key_classes": [
+      "App\\Etc\\Start",
+      "App\\Etc\\Routes",
+      "App\\Etc\\Application",
+      "App\\Etc\\Config\\ConfigManager",
+      "App\\Etc\\Config\\Environment",
+      "App\\Etc\\InitModsImproved",
+      "App\\Etc\\Router"
+    ]
+  },
+  "config": {
+    "priority": [
+      "1. src/Etc/.env (Environment)",
+      "2. ConfigManager structured config (app, database, cache, session, security, mail, logging)",
+      "3. Config.php legacy fallbacks (site_path, domain_name, static session defaults)",
+      "4. ConfigDatabase.php DB fallbacks (development only)"
+    ],
+    "required_env": ["DOMAIN_NAME", "SITE_PATH", "APP_ENV"],
+    "important_env": {
+      "APP_DEBUG": "Controls error display — use this, not APP_ENV alone",
+      "APP_KEY": "Application secret — generate for production",
+      "DB_HOST": "Database host",
+      "DB_NAME": "Database name",
+      "DB_USER": "Database user",
+      "DB_PASS": "Database password",
+      "DB_CHARSET": "Database charset (default utf8mb4)",
+      "SESSION_COOKIE": "Session cookie name",
+      "SESSION_SAME_SITE": "lax | strict | none",
+      "SESSION_SECURE": "true if HTTPS",
+      "JWT_SECRET": "Required for JWT middleware",
+      "PROTECTED_ROUTES": "Comma-separated route prefixes requiring session auth",
+      "ROUTE_USE_CACHE": "Module discovery cache — overrides production auto-detect when set",
+      "CACHE_DRIVER": "file | array — default cache store for CacheManager",
+      "LOG_PATH": "Error log directory (relative to app root or absolute)",
+      "CORS_ENABLED": "Global CORS via ConfigManager app.cors.enabled"
+    },
+    "access_patterns": {
+      "correct": [
+        "Environment::get('KEY', 'default')",
+        "ConfigManager::get('app.debug', false)",
+        "ConfigManager::get('session.lifetime', 3600)"
+      ],
+      "avoid": [
+        "$_ENV['KEY'] for .env values — putenv does not populate $_ENV",
+        "Hardcoding credentials in PHP files"
+      ]
+    }
+  },
+  "routing": {
+    "discovery": "InitModsImproved scans src/Modules/*/Routes/Routes.php and nested Modules/*/Modules/*/Routes/Routes.php",
+    "route_methods": [
+      "addRoute(path, controller, method, middleware[], methods[]) — middleware is 4th argument array",
+      "addParamRoute(path, controller, method, middleware[], constraints[], methods[]) — supports {id:int} typed params in $_GET"
+    ],
+    "middleware_registration": "Start.php registers global + named middleware (csrf, rate_limit, jwt, auth, cors)",
+    "protected_routes": "PROTECTED_ROUTES in .env merges with Start::$defaultProtectedRoutes and Application::addProtectedRoutes()",
+    "docs": [
+      "docs/routing/ROUTING_GUIDE.md",
+      "docs/PROTECTED_ROUTES_IMPLEMENTED.md",
+      "docs/JWT_AUTHENTICATION.md"
+    ]
+  },
+  "middleware": {
+    "global": ["LoggingMiddleware", "CorsMiddleware (if app.cors.enabled)", "AuthMiddleware (protected routes)"],
+    "named": {
+      "csrf": "POST CSRF validation via Security::validateCsrf",
+      "rate_limit": "IP rate limit via Security::rateLimit + security.rate_limit config",
+      "jwt": "Bearer JWT — sets $GLOBALS['current_user']",
+      "auth": "Session check $_SESSION['logged']",
+      "cors": "Route-level CORS (global CORS preferred when cross-origin)"
+    },
+    "note_cors_tag": "Adding 'cors' to route middleware array only works if cors named middleware is used; global CORS uses CORS_ENABLED in .env"
+  },
+  "modules": {
+    "namespace": "App\\Modules\\{Name}",
+    "base_classes": {
+      "controller": "App\\Common\\Bmvc\\BaseController",
+      "model": "App\\Common\\Bmvc\\BaseModel",
+      "view": "App\\Common\\Bmvc\\BaseView",
+      "orm_optional": "App\\Common\\Bmvc\\BaseModelOrm (requires RedBean — optional)"
+    },
+    "generator": "src/Tools/ModuleGeneratorEnhanced/ — scaffolds modules with Routes, Controller, Model, View",
+    "philosophy": "Bundled modules (Auth, Admin, React*, etc.) are reference implementations — delete what you do not need"
+  },
+  "packages": {
+    "summary": "Composer packages extend upMVC via optional src/Etc/packages.php provider registry",
+    "registry_file": "src/Etc/packages.php",
+    "registry_note": "File is optional in standalone upMVC; required pattern for upMVC-SaaS and library-mode apps",
+    "registry_format": "return [ \\Vendor\\Package\\ServiceProvider::class, ... ];",
+    "application_api": {
+      "addModulePath": "Register extra module scan paths — prepend for pack, append for app overrides",
+      "addMigrationPath": "Register migration directories",
+      "addProtectedRoutes": "Register route prefixes requiring auth",
+      "registerProviders": "Called from Start before middleware",
+      "bootProviders": "Called after middleware registration — wire routes, factories"
+    },
+    "module_path_order": "Pack paths registered first; app src/Modules scanned last so app routes override pack routes",
+    "library_mode": {
+      "constant": "UPMVC_APP_ROOT",
+      "description": "When upMVC is a Composer dependency, host app defines UPMVC_APP_ROOT before autoload so Application resolves host paths for .env, packages.php, and local modules"
+    },
+    "example_saas_starter": {
+      "repo": "upMVC-SaaS",
+      "packages_php": "src/Etc/packages.php returns BitsHost\\UpmvcSaas\\SaasServiceProvider::class",
+      "composer_packages": ["bitshost/upmvc", "bitshost/upmvc-saas-pack"],
+      "docs": "See docs/agent/upmvc-saas-pack.json for SaaS-specific knowledge"
+    }
+  },
+  "cache_and_tools": {
+    "cache_manager": "App\\Etc\\Cache\\CacheManager — multi-store cache, respects CACHE_DRIVER",
+    "legacy_cache": "App\\Etc\\Cache — older file cache using Config::get('cache.enabled') — prefer CacheManager for new code",
+    "cache_cli": "php src/Tools/cache-cli.php list|stats|clear:modules|clear:admin|clear:all",
+    "admin_route_cache_note": "Admin dynamic routes cache at src/Etc/storage/cache/admin_routes.php; module discovery uses storage/cache via CacheManager",
+    "agent_cli": "php src/Tools/upmvc-next.php — builds agent prompt from this knowledge pack"
+  },
+  "security_baseline": {
+    "csrf": "Security::csrfToken() in forms; validate on POST",
+    "passwords": "password_hash / password_verify — never plain text",
+    "sessions": "session_regenerate_id(true) after login",
+    "jwt": "Read JWT_SECRET via Environment::get(), not $_ENV",
+    "rate_limiting": "Security::rateLimit for simple; App\\Common\\Helpers\\RateLimiter for per-action file-persisted limits"
+  },
+  "agent_behavior": {
+    "user_experience": "User is already inside the framework — do not make them explain upMVC basics. Ask what they want to build, then plan.",
+    "default_mode": "plan_first",
+    "plan_output": "JSON plan with steps, files_touched, config_changes, risks — wait for approval before writing files",
+    "when_unsure": "Read existing module in src/Modules as reference before inventing patterns"
+  }
+}

--- a/docs/agent/upmvc-rules.json
+++ b/docs/agent/upmvc-rules.json
@@ -1,0 +1,65 @@
+{
+  "meta": {
+    "name": "upMVC Agent Rules",
+    "version": "1.0.1",
+    "verified_against": "upMVC v2.3.6",
+    "severity": "These are hard constraints. Violations must be fixed before code is accepted."
+  },
+  "must": [
+    "Read config with Environment::get() or ConfigManager::get() — never $_ENV for .env values",
+    "Place new modules under src/Modules/{Name}/ with Routes/Routes.php for auto-discovery",
+    "Use namespace App\\Modules\\{Name} for application modules",
+    "Use PDO prepared statements for all SQL — never interpolate user input into queries",
+    "Hash passwords with password_hash() and verify with password_verify()",
+    "Include CSRF protection on session-based POST forms",
+    "Register JWT routes with ['jwt'] middleware when using bearer token auth",
+    "Match existing code style, naming, and file layout in the target module",
+    "Return a structured plan before creating or modifying multiple files",
+    "Use Application::getInstance()->path() for filesystem paths — avoid hardcoded relative paths"
+  ],
+  "never": [
+    "Store or compare passwords in plain text",
+    "Use $_ENV['MAIL_*'] or $_ENV['JWT_SECRET'] as primary config source",
+    "Use FILTER_SANITIZE_STRING (removed in PHP 8.1)",
+    "Apply htmlspecialchars() before database storage — encode at output in views",
+    "Hardcode credentials, API keys, or secrets in PHP files",
+    "Manually register modules in InitModsImproved when auto-discovery works",
+    "Use unserialize() without ['allowed_classes' => false] on untrusted data",
+    "Use rand() for security tokens — use random_bytes() or random_int()",
+    "Redirect to user-controlled URLs without validating against BASE_URL",
+    "Invent framework APIs that do not exist — verify in src/Etc/ first"
+  ],
+  "saas_must": [
+    "Scope every tenant data query with tenant_id — use prepared statement binding",
+    "For JWT tenant APIs use $this->user['tenant_id'] from SaasApiController; for web shell use $GLOBALS['current_tenant']",
+    "Protected tenant APIs: middleware ['cors', 'jwt'] as 4th addRoute argument — not ->middleware() chaining",
+    "Use ['tenant'] middleware on web shell routes that need TenantMiddleware slug/subdomain resolution",
+    "Use ['feature:flagname'] only when plan gating is required (PlanGateMiddleware factory)",
+    "Never expose cross-tenant data — if tenant_id is missing, fail closed"
+  ],
+  "prefer": [
+    "Extend BaseController / BaseModel / BaseView over reinventing base classes",
+    "ConfigManager dot keys over duplicating env reads",
+    "InitModsImproved + module Routes.php over editing core router",
+    "ModuleGeneratorEnhanced for scaffolding over hand-rolling boilerplate",
+    "Small focused diffs — one concern per change set"
+  ],
+  "output_format": {
+    "phase": "plan | implement | review",
+    "required_fields": [
+      "understanding",
+      "assumptions",
+      "plan",
+      "files_touched",
+      "config_changes",
+      "risks",
+      "next_step_for_human"
+    ],
+    "plan_step_schema": {
+      "step": "number",
+      "action": "create_module | add_route | migration | config | fix | test",
+      "details": "string",
+      "files": ["array of paths"]
+    }
+  }
+}

--- a/docs/agent/upmvc-saas-pack.json
+++ b/docs/agent/upmvc-saas-pack.json
@@ -1,0 +1,112 @@
+{
+  "meta": {
+    "name": "upMVC SaaS Pack Knowledge",
+    "version": "1.0.1",
+    "verified_against": "bitshost/upmvc-saas-pack + upMVC v2.3.6",
+    "applies_when": [
+      "composer package bitshost/upmvc-saas-pack is installed",
+      "src/Etc/packages.php registers BitsHost\\UpmvcSaas\\SaasServiceProvider",
+      "Project is upMVC-SaaS or similar SaaS starter"
+    ],
+    "companion_repo": "upMVC-SaaS"
+  },
+  "architecture": {
+    "three_pieces": {
+      "bitshost/upmvc": "Core framework kernel — routing, config, middleware, module discovery",
+      "bitshost/upmvc-saas-pack": "Reusable SaaS modules, middleware, provider, demo schema",
+      "upMVC-SaaS": "Starter app wiring both packages via Composer"
+    },
+    "request_flow": [
+      "HTTP → public/index.php (UPMVC_APP_ROOT)",
+      "vendor/bitshost/upmvc → Start.php",
+      "src/Etc/packages.php → SaasServiceProvider",
+      "Router + middleware → SaaS or app module controller"
+    ]
+  },
+  "provider": {
+    "class": "BitsHost\\UpmvcSaas\\SaasServiceProvider",
+    "register": "Adds module paths, migration paths, protected routes",
+    "boot": "Registers tenant middleware, feature:* factory, SaaS routes"
+  },
+  "module_paths": {
+    "pack": "vendor/bitshost/upmvc-saas-pack/src/Modules",
+    "app": "src/Modules (optional — create for local overrides)",
+    "order": "Pack scanned first, app modules last — app wins on route conflicts"
+  },
+  "pack_modules": {
+    "note": "Pack ships under vendor/.../src/Modules/. Your app adds domain modules under src/Modules/Api/{Domain}/",
+    "pack_api_modules": "Api/Modules/Auth, Api/Modules/Plans, Api/Modules/Tenants, Api/Modules/Admin",
+    "pack_web_modules": "Auth, Home, PlatformAdmin, TenantApp, TenantShop, Mail",
+    "routes": {
+      "Api/Modules/Auth": "POST /api/auth/login, /refresh, /logout",
+      "Api/Modules/Plans": "GET /api/plans, /api/plans/{id}",
+      "Api/Modules/Tenants": "POST /api/tenants/register and tenant APIs",
+      "Api/Modules/Admin": "Platform admin APIs (platform_admin role)"
+    }
+  },
+  "middleware": {
+    "jwt": {
+      "source": "upMVC core",
+      "sets": "$GLOBALS['current_user']",
+      "usage": "['jwt'] on API routes"
+    },
+    "tenant": {
+      "source": "SaaS pack — BitsHost\\UpmvcSaas\\Middleware\\TenantMiddleware",
+      "sets": "$GLOBALS['current_tenant']",
+      "usage": "['tenant'] on web shell routes — not required on standard JWT tenant APIs",
+      "resolves_from": "URL slug /app/{slug}/... or subdomain"
+    },
+    "feature": {
+      "source": "SaaS pack — BitsHost\\UpmvcSaas\\Middleware\\PlanGateMiddleware via factory",
+      "usage": "['feature:efactura'] as 4th addRoute argument — plan feature gating",
+      "factory": "Router::registerMiddlewareFactory('feature', fn($f) => new PlanGateMiddleware($f))"
+    },
+    "cors": {
+      "note": "Enable CORS_ENABLED=true in .env for cross-origin clients. Route-level 'cors' tag is not a substitute for global CORS config."
+    }
+  },
+  "tenancy": {
+    "model": "Shared database, shared schema — rows filtered by tenant_id",
+    "core_tables": ["users", "tenants", "plans", "refresh_tokens"],
+    "tenant_registration": "POST /api/tenants/register — creates tenant + owner atomically",
+    "tenant_status": ["trial", "active", "suspended"],
+    "context_in_controller": {
+      "jwt_tenant_api": "$this->user['tenant_id'] from JWT — primary source for tenant-scoped API queries",
+      "web_shell": "$GLOBALS['current_tenant'] when ['tenant'] middleware is used",
+      "shortcut": "$this->tenantId on SaasApiController — populated from current_tenant row when tenant middleware ran"
+    }
+  },
+  "roles": {
+    "platform_admin": "Full Api/Admin access — no tenant_id",
+    "tenant_owner": "Full access within tenant",
+    "tenant_user": "Limited access within tenant — app-defined"
+  },
+  "api_module_pattern": {
+    "controller": "extends BitsHost\\UpmvcSaas\\Http\\SaasApiController",
+    "helpers": ["$this->user", "$this->tenant", "$this->tenantId", "$this->success()", "$this->error()", "$this->body()", "$this->requireFields()"],
+    "model": "All tenant queries scoped: WHERE tenant_id = :tid using $this->user['tenant_id'] on JWT APIs",
+    "routes_example": "$router->addRoute('/api/bookings', Controller::class, 'index', ['cors', 'jwt'], ['GET']);"
+  },
+  "domain_module_contract": {
+    "description": "Your SaaS-specific code — only layer you write per product",
+    "location": "src/Modules/Api/{Domain}/ (app repo — not inside vendor pack)",
+    "structure": ["Controller.php", "Model.php", "Routes/Routes.php"],
+    "shared_modules_reused": ["Tenants", "Plans", "Auth", "PlatformAdmin", "TenantApp"]
+  },
+  "lessons_from_production": [
+    "BaseModel CRUD method names may conflict — use app-level AppBaseModel wrapper if needed",
+    "Use dispatch() pattern on API controllers for multi-verb routes instead of manual REQUEST_METHOD checks",
+    "Split large View.php into Views/ partials when exceeding ~400 lines",
+    "RateLimiter (file-based) preferred over session-only Security::rateLimit for login/signup",
+    "Validate input at controller boundary — model receives clean typed data"
+  ],
+  "docs_in_saas_repo": [
+    "docs/02-architecture.md",
+    "docs/03-getting-started.md",
+    "docs/04-api-modules.md",
+    "docs/05-auth-jwt.md",
+    "docs/06-tenants-plans.md",
+    "docs/07-platform-admin.md",
+    "docs/08-your-way.md"
+  ]
+}

--- a/docs/agent/upmvc-workflows.json
+++ b/docs/agent/upmvc-workflows.json
@@ -1,0 +1,110 @@
+{
+  "meta": {
+    "name": "upMVC Agent Workflows",
+    "version": "1.0.1",
+    "verified_against": "upMVC v2.3.6",
+    "instruction": "Match user intent to a workflow. Output plan JSON before implementation."
+  },
+  "workflows": {
+    "create_module": {
+      "intent_keywords": ["module", "feature", "crud", "new page", "scaffold"],
+      "steps": [
+        "Confirm module name (PascalCase) and type: web | api | both",
+        "Check if similar module exists in src/Modules for pattern reference",
+        "Scaffold with ModuleGeneratorEnhanced or hand-create Controller, Model, View, Routes/Routes.php",
+        "Register routes in Routes/Routes.php using addRoute(path, class, method, [middleware], [methods]) or addParamRoute",
+        "Add middleware array if auth/csrf/jwt required",
+        "Add view templates if web module",
+        "Verify module appears in InitMods discovery (no manual registration)"
+      ],
+      "files_touched": [
+        "src/Modules/{Name}/Controller.php",
+        "src/Modules/{Name}/Model.php",
+        "src/Modules/{Name}/View.php",
+        "src/Modules/{Name}/Routes/Routes.php"
+      ]
+    },
+    "add_api_route": {
+      "intent_keywords": ["api", "endpoint", "rest", "json"],
+      "steps": [
+        "Identify target module or create Api/{Domain} module",
+        "Add route in Routes/Routes.php",
+        "Implement controller method returning JSON (success/error helpers if SaaS)",
+        "Apply middleware as 4th addRoute argument: ['cors', 'jwt'] for protected APIs",
+        "Validate input at controller; use prepared statements in model",
+        "Document method in module or docs if public API"
+      ]
+    },
+    "saas_domain_module": {
+      "intent_keywords": ["saas", "tenant", "booking", "product", "domain"],
+      "requires": "bitshost/upmvc-saas-pack",
+      "steps": [
+        "Confirm SaaS pack is installed and packages.php registers SaasServiceProvider",
+        "Create src/Modules/Api/{Domain}/ with Controller extending BitsHost\\UpmvcSaas\\Http\\SaasApiController",
+        "Model: scope queries with tenant_id from $this->user['tenant_id'] (JWT APIs)",
+        "Routes: addRoute(..., ['cors', 'jwt'], [methods]) for protected tenant APIs",
+        "Migration: add table with tenant_id column and index",
+        "Test with JWT from /api/auth/login — never skip tenant scoping"
+      ],
+      "reference": "docs/agent/upmvc-saas-pack.json"
+    },
+    "config_audit": {
+      "intent_keywords": ["config", "env", "settings", "audit", "wiring"],
+      "steps": [
+        "Read src/Etc/.env.example and compare to src/Etc/.env",
+        "Grep codebase for Environment::get, ConfigManager::get, $_ENV, Config::get",
+        "Map each env key to consumer class",
+        "Flag unused keys and unwired keys",
+        "Propose minimal fixes — prefer ConfigManager over new globals"
+      ],
+      "reference": "docs/CORE_AREAS_AND_CONFIGURATION.md"
+    },
+    "add_package_provider": {
+      "intent_keywords": ["package", "provider", "composer", "extend", "pack"],
+      "steps": [
+        "composer require vendor/package",
+        "Add ServiceProvider class to src/Etc/packages.php return array",
+        "Provider register(): addModulePath, addMigrationPath, addProtectedRoutes as needed",
+        "Provider boot(): register routes, middleware factories",
+        "Confirm UPMVC_APP_ROOT points to host app when upMVC is library dependency"
+      ]
+    },
+    "fix_auth": {
+      "intent_keywords": ["login", "auth", "session", "jwt", "protected"],
+      "steps": [
+        "Identify auth mode: session (web) | jwt (api) | both",
+        "Session: PROTECTED_ROUTES in .env + AuthMiddleware + CSRF on POST",
+        "JWT: JWT_SECRET in .env + jwt middleware on routes",
+        "SaaS: use pack Api/Auth + refresh token flow",
+        "Verify password_hash on store, session_regenerate_id on login"
+      ]
+    },
+    "debug_routing": {
+      "intent_keywords": ["404", "route", "not found", "middleware"],
+      "steps": [
+        "Check InitModsImproved discovery — module Routes.php path correct",
+        "Clear route cache: php src/Tools/cache-cli.php clear:modules",
+        "Verify ROUTE_USE_CACHE and APP_ENV",
+        "Check middleware blocking before controller",
+        "Inspect protected route prefixes vs actual URL path"
+      ]
+    },
+    "cache_operations": {
+      "intent_keywords": ["cache", "slow", "stale routes"],
+      "steps": [
+        "php src/Tools/cache-cli.php stats",
+        "php src/Tools/cache-cli.php clear:modules",
+        "Verify CACHE_DRIVER in .env matches CacheManager usage"
+      ]
+    }
+  },
+  "intent_router": {
+    "description": "Map free-text user goal to workflow id",
+    "examples": [
+      { "user_says": "I need a bookings API for my SaaS", "workflow": "saas_domain_module" },
+      { "user_says": "Add a contact form module", "workflow": "create_module" },
+      { "user_says": "Why is my env not working", "workflow": "config_audit" },
+      { "user_says": "Hook in the saas pack", "workflow": "add_package_provider" }
+    ]
+  }
+}

--- a/docs/subjects/guides/README.md
+++ b/docs/subjects/guides/README.md
@@ -6,4 +6,5 @@ Links — sorted by date pending Git history:
 - [FAQ.md](../../FAQ.md)
 - [FIRST-STEPS-GUIDE.md](../../FIRST-STEPS-GUIDE.md)
 - [HOW-TO-GUIDE.md](../../HOW-TO-GUIDE.md)
+- [AGENT_PACK.md](../../AGENT_PACK.md)
 - [examples/](../../examples/)

--- a/src/Tools/upmvc-next.php
+++ b/src/Tools/upmvc-next.php
@@ -1,0 +1,455 @@
+<?php
+/**
+ * upmvc-next.php — upMVC Agent prompt builder
+ *
+ * Puts the user in the middle of the house: scan project, ask what they want,
+ * output a prompt package for any AI agent (Cursor, Claude, API, etc.).
+ *
+ * Usage (from project root):
+ *   php src/Tools/upmvc-next.php
+ *   php src/Tools/upmvc-next.php --goal "Add a bookings API for my SaaS"
+ *   php src/Tools/upmvc-next.php --stdout
+ *
+ * Output:
+ *   docs/agent/generated/last-prompt.md
+ *   docs/agent/generated/last-session.json
+ */
+
+declare(strict_types=1);
+
+final class UpmvcNext
+{
+    private string $appRoot;
+    private string $agentDir;
+    private string $generatedDir;
+
+    /** @var array<string, mixed> */
+    private array $knowledge = [];
+    /** @var array<string, mixed> */
+    private array $rules = [];
+    /** @var array<string, mixed> */
+    private array $workflows = [];
+    /** @var array<string, mixed> */
+    private array $saasPack = [];
+
+    public function __construct(?string $appRoot = null)
+    {
+        $this->appRoot = $this->resolveAppRoot($appRoot);
+        $this->agentDir = $this->appRoot . '/docs/agent';
+        $this->generatedDir = $this->agentDir . '/generated';
+    }
+
+    public function run(array $argv): int
+    {
+        $goal = null;
+        $stdoutOnly = in_array('--stdout', $argv, true);
+
+        foreach ($argv as $i => $arg) {
+            if ($arg === '--goal' && isset($argv[$i + 1])) {
+                $goal = $argv[$i + 1];
+            }
+        }
+
+        if (!$this->loadAgentPack()) {
+            return 1;
+        }
+
+        $scan = $this->scanProject();
+        $this->banner($scan);
+
+        if ($goal === null || trim($goal) === '') {
+            $goal = $this->askGoal();
+        }
+
+        $workflow = $this->matchWorkflow($goal);
+        $session = $this->buildSession($scan, $goal, $workflow);
+        $prompt = $this->buildPrompt($session);
+
+        if ($stdoutOnly) {
+            echo $prompt;
+            return 0;
+        }
+
+        if (!$this->writeOutput($session, $prompt)) {
+            return 1;
+        }
+
+        $this->printDone();
+        return 0;
+    }
+
+    private function resolveAppRoot(?string $appRoot): string
+    {
+        if ($appRoot !== null && is_dir($appRoot)) {
+            return realpath($appRoot) ?: $appRoot;
+        }
+
+        if (defined('UPMVC_APP_ROOT') && is_dir((string) UPMVC_APP_ROOT)) {
+            return realpath((string) UPMVC_APP_ROOT) ?: (string) UPMVC_APP_ROOT;
+        }
+
+        $candidate = realpath(__DIR__ . '/../..');
+        if ($candidate !== false && is_dir($candidate . '/src/Etc')) {
+            return $candidate;
+        }
+
+        return getcwd() ?: '.';
+    }
+
+    private function loadAgentPack(): bool
+    {
+        $required = [
+            'knowledge' => 'upmvc-knowledge.json',
+            'rules' => 'upmvc-rules.json',
+            'workflows' => 'upmvc-workflows.json',
+        ];
+
+        foreach ($required as $prop => $file) {
+            $path = $this->agentDir . '/' . $file;
+            if (!is_file($path)) {
+                $this->err("Missing agent pack file: {$path}");
+                $this->err('Run this from an upMVC project with docs/agent/ installed.');
+                return false;
+            }
+
+            $decoded = json_decode((string) file_get_contents($path), true);
+            if (!is_array($decoded)) {
+                $this->err("Invalid JSON: {$path}");
+                return false;
+            }
+
+            $this->{$prop} = $decoded;
+        }
+
+        $saasPath = $this->agentDir . '/upmvc-saas-pack.json';
+        if (is_file($saasPath)) {
+            $decoded = json_decode((string) file_get_contents($saasPath), true);
+            if (!is_array($decoded)) {
+                $this->err("Invalid JSON: {$saasPath}");
+                return false;
+            }
+            $this->saasPack = $decoded;
+        }
+
+        return true;
+    }
+
+    private function hasSaasPackFile(): bool
+    {
+        return $this->saasPack !== [];
+    }
+
+    /** @return array<string, mixed> */
+    private function scanProject(): array
+    {
+        $modulesPath = $this->appRoot . '/src/Modules';
+        $modules = [];
+
+        if (is_dir($modulesPath)) {
+            foreach (scandir($modulesPath) ?: [] as $entry) {
+                if ($entry === '.' || $entry === '..') {
+                    continue;
+                }
+                $moduleDir = $modulesPath . '/' . $entry;
+                if (!is_dir($moduleDir)) {
+                    continue;
+                }
+                $hasRoutes = is_file($moduleDir . '/Routes/Routes.php');
+                $modules[] = [
+                    'name' => $entry,
+                    'has_routes' => $hasRoutes,
+                ];
+            }
+        }
+
+        usort($modules, static fn(array $a, array $b): int => strcmp($a['name'], $b['name']));
+
+        $packagesFile = $this->appRoot . '/src/Etc/packages.php';
+        $providers = [];
+        if (is_file($packagesFile)) {
+            $loaded = require $packagesFile;
+            if (is_array($loaded)) {
+                $providers = array_values(array_filter($loaded, 'is_string'));
+            }
+        }
+
+        $composer = $this->readComposer();
+        $isSaas = $this->detectSaas($composer, $providers);
+        $includeSaasPack = $isSaas && $this->hasSaasPackFile();
+
+        return [
+            'app_root' => $this->appRoot,
+            'framework' => 'upMVC',
+            'has_env' => is_file($this->appRoot . '/src/Etc/.env'),
+            'has_env_example' => is_file($this->appRoot . '/src/Etc/.env.example'),
+            'env_path' => 'src/Etc/.env',
+            'has_env_legacy_root' => is_file($this->appRoot . '/.env'),
+            'modules' => $modules,
+            'module_count' => count($modules),
+            'packages_php' => is_file($packagesFile),
+            'providers' => $providers,
+            'composer_require' => $composer['require'] ?? [],
+            'is_saas' => $isSaas,
+            'has_saas_pack_file' => $this->hasSaasPackFile(),
+            'include_saas_pack' => $includeSaasPack,
+            'agent_pack_version' => $this->knowledge['meta']['version'] ?? 'unknown',
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function readComposer(): array
+    {
+        $path = $this->appRoot . '/composer.json';
+        if (!is_file($path)) {
+            return [];
+        }
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /** @param array<string, mixed> $composer */
+    /** @param list<string> $providers */
+    private function detectSaas(array $composer, array $providers): bool
+    {
+        $require = $composer['require'] ?? [];
+        if (is_array($require)) {
+            foreach (array_keys($require) as $pkg) {
+                if (stripos((string) $pkg, 'upmvc-saas-pack') !== false) {
+                    return true;
+                }
+            }
+        }
+
+        foreach ($providers as $provider) {
+            if (stripos($provider, 'Saas') !== false || stripos($provider, 'UpmvcSaas') !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** @param array<string, mixed> $scan */
+    private function banner(array $scan): void
+    {
+        $this->out('');
+        $this->out('  upMVC — you are already inside the house.');
+        $this->out('  ─────────────────────────────────────────');
+        $this->out('  Project:  ' . $scan['app_root']);
+        $this->out('  Modules:  ' . $scan['module_count'] . ' in src/Modules/');
+        if ($scan['is_saas']) {
+            $this->out('  Mode:     SaaS (pack detected)');
+        } else {
+            $this->out('  Mode:     Standalone upMVC');
+        }
+        if (!$scan['has_env']) {
+            $this->out('  Note:     src/Etc/.env not found — copy from src/Etc/.env.example');
+            if ($scan['has_env_legacy_root'] ?? false) {
+                $this->out('  Note:     .env at project root is not loaded — move/copy to src/Etc/.env');
+            }
+        }
+        $this->out('');
+    }
+
+    private function askGoal(): string
+    {
+        $this->out('What do you want to do? (one line — examples below)');
+        $this->out('  • Add a contact form module');
+        $this->out('  • Bookings API for my SaaS tenants');
+        $this->out('  • Audit why my .env settings are ignored');
+        $this->out('  • Fix JWT login on /api/auth');
+        $this->out('');
+        $this->out('Your goal: ', false);
+
+        $line = fgets(STDIN);
+        $goal = is_string($line) ? trim($line) : '';
+
+        if ($goal === '') {
+            $goal = 'Explore the project and suggest the highest-value next step';
+        }
+
+        return $goal;
+    }
+
+    /** @return array{id: string, label: string}|null */
+    private function matchWorkflow(string $goal): ?array
+    {
+        $lower = strtolower($goal);
+        $workflows = $this->workflows['workflows'] ?? [];
+
+        $best = null;
+        $bestScore = 0;
+
+        foreach ($workflows as $id => $wf) {
+            if (!is_array($wf)) {
+                continue;
+            }
+            $keywords = $wf['intent_keywords'] ?? [];
+            $score = 0;
+            foreach ($keywords as $kw) {
+                if (is_string($kw) && str_contains($lower, strtolower($kw))) {
+                    $score++;
+                }
+            }
+            if ($score > $bestScore) {
+                $bestScore = $score;
+                $best = ['id' => (string) $id, 'label' => (string) ($wf['description'] ?? $id)];
+            }
+        }
+
+        return $best;
+    }
+
+    /** @param array<string, mixed> $scan */
+    /** @param array{id: string, label: string}|null $workflow */
+    /** @return array<string, mixed> */
+    private function buildSession(array $scan, string $goal, ?array $workflow): array
+    {
+        $wfId = $workflow['id'] ?? 'explore';
+        $wfData = $this->workflows['workflows'][$wfId] ?? null;
+
+        return [
+            'generated_at' => date('c'),
+            'goal' => $goal,
+            'workflow' => $wfId,
+            'workflow_steps' => is_array($wfData) ? ($wfData['steps'] ?? []) : [],
+            'scan' => $scan,
+            'include_saas_pack' => (bool) ($scan['include_saas_pack'] ?? false),
+            'agent_files' => [
+                'knowledge' => 'docs/agent/upmvc-knowledge.json',
+                'rules' => 'docs/agent/upmvc-rules.json',
+                'workflows' => 'docs/agent/upmvc-workflows.json',
+                'saas' => ($scan['include_saas_pack'] ?? false)
+                    ? 'docs/agent/upmvc-saas-pack.json'
+                    : null,
+            ],
+            'rules_must' => array_slice($this->rules['must'] ?? [], 0, 8),
+            'rules_never' => array_slice($this->rules['never'] ?? [], 0, 8),
+        ];
+    }
+
+    /** @param array<string, mixed> $session */
+    private function buildPrompt(array $session): string
+    {
+        $lines = [];
+        $lines[] = '# upMVC Agent Session';
+        $lines[] = '';
+        $lines[] = 'You are inside an upMVC project. **Do not ask the user to explain the framework.**';
+        $lines[] = '';
+        $lines[] = '## User goal';
+        $lines[] = $session['goal'];
+        $lines[] = '';
+        $lines[] = '## Project snapshot';
+        $scan = $session['scan'];
+        $lines[] = '- App root: `' . $scan['app_root'] . '`';
+        $lines[] = '- Modules (' . $scan['module_count'] . '): ' . $this->formatModuleList($scan['modules']);
+        $lines[] = '- SaaS mode: ' . ($scan['is_saas'] ? 'yes' : 'no');
+        if (!empty($scan['providers'])) {
+            $lines[] = '- Providers: ' . implode(', ', $scan['providers']);
+        }
+        $lines[] = '';
+        $lines[] = '## Workflow: `' . $session['workflow'] . '`';
+        foreach ($session['workflow_steps'] as $step) {
+            if (is_string($step)) {
+                $lines[] = '- ' . $step;
+            }
+        }
+        $lines[] = '';
+        $lines[] = '## Load context (required)';
+        foreach ($session['agent_files'] as $key => $path) {
+            if ($path !== null) {
+                $lines[] = '- `' . $path . '`';
+            }
+        }
+        $lines[] = '';
+        $lines[] = '## Rules (summary — full list in upmvc-rules.json)';
+        $lines[] = '**Must:**';
+        foreach ($session['rules_must'] as $rule) {
+            $lines[] = '- ' . $rule;
+        }
+        $lines[] = '';
+        $lines[] = '**Never:**';
+        foreach ($session['rules_never'] as $rule) {
+            $lines[] = '- ' . $rule;
+        }
+        if ($session['include_saas_pack']) {
+            $lines[] = '';
+            $lines[] = '## SaaS';
+            $lines[] = 'This project uses the SaaS pack. All tenant data queries must filter by `tenant_id`.';
+            $lines[] = 'Use `docs/agent/upmvc-saas-pack.json` for middleware and module patterns.';
+        }
+        $lines[] = '';
+        $lines[] = '## Your task';
+        $lines[] = '1. Confirm understanding in 2–3 sentences.';
+        $lines[] = '2. Output a JSON **plan** (steps, files_touched, config_changes, risks) — wait for approval before editing.';
+        $lines[] = '3. Match existing patterns in `src/Modules/` before inventing new ones.';
+        $lines[] = '';
+
+        return implode("\n", $lines);
+    }
+
+    /** @param list<array{name: string, has_routes: bool}> $modules */
+    private function formatModuleList(array $modules): string
+    {
+        if ($modules === []) {
+            return '(none yet)';
+        }
+
+        $names = array_map(static fn(array $m): string => $m['name'], $modules);
+        $preview = array_slice($names, 0, 12);
+        $text = implode(', ', $preview);
+        if (count($names) > 12) {
+            $text .= ', ...';
+        }
+        return $text;
+    }
+
+    /** @param array<string, mixed> $session */
+    private function writeOutput(array $session, string $prompt): bool
+    {
+        if (!is_dir($this->generatedDir) && !mkdir($this->generatedDir, 0755, true) && !is_dir($this->generatedDir)) {
+            $this->err('Could not create: ' . $this->generatedDir);
+            return false;
+        }
+
+        $promptPath = $this->generatedDir . '/last-prompt.md';
+        $sessionPath = $this->generatedDir . '/last-session.json';
+
+        if (file_put_contents($promptPath, $prompt) === false) {
+            $this->err('Failed to write: ' . $promptPath);
+            return false;
+        }
+
+        $json = json_encode($session, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        if ($json === false || file_put_contents($sessionPath, $json) === false) {
+            $this->err('Failed to write: ' . $sessionPath);
+            return false;
+        }
+
+        $this->out('Written:');
+        $this->out('  ' . $promptPath);
+        $this->out('  ' . $sessionPath);
+        return true;
+    }
+
+    private function printDone(): void
+    {
+        $this->out('');
+        $this->out('Paste last-prompt.md into Cursor or your agent chat.');
+        $this->out('Or re-run with: php src/Tools/upmvc-next.php --stdout');
+        $this->out('');
+    }
+
+    private function out(string $text, bool $newline = true): void
+    {
+        echo $text . ($newline ? PHP_EOL : '');
+    }
+
+    private function err(string $text): void
+    {
+        fwrite(STDERR, $text . PHP_EOL);
+    }
+}
+
+exit((new UpmvcNext())->run($argv));

--- a/tests/Unit/Tools/AgentPackTest.php
+++ b/tests/Unit/Tools/AgentPackTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Unit\Tools;
+
+use PHPUnit\Framework\TestCase;
+
+class AgentPackTest extends TestCase
+{
+    private string $root;
+    private string $agentDir;
+
+    protected function setUp(): void
+    {
+        $this->root = dirname(__DIR__, 3);
+        $this->agentDir = $this->root . '/docs/agent';
+    }
+
+    public function test_agent_pack_json_files_exist_and_parse(): void
+    {
+        $files = [
+            'upmvc-knowledge.json',
+            'upmvc-rules.json',
+            'upmvc-workflows.json',
+            'upmvc-saas-pack.json',
+        ];
+
+        foreach ($files as $file) {
+            $path = $this->agentDir . '/' . $file;
+            $this->assertFileExists($path, $file . ' should exist');
+
+            $data = json_decode((string) file_get_contents($path), true);
+            $this->assertIsArray($data, $file . ' should decode to array');
+            $this->assertArrayHasKey('meta', $data, $file . ' should have meta key');
+        }
+    }
+
+    public function test_rules_pack_has_must_and_never_arrays(): void
+    {
+        $data = json_decode(
+            (string) file_get_contents($this->agentDir . '/upmvc-rules.json'),
+            true
+        );
+
+        $this->assertIsArray($data);
+        $this->assertNotEmpty($data['must'] ?? []);
+        $this->assertNotEmpty($data['never'] ?? []);
+    }
+
+    public function test_workflows_pack_has_create_module_recipe(): void
+    {
+        $data = json_decode(
+            (string) file_get_contents($this->agentDir . '/upmvc-workflows.json'),
+            true
+        );
+
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('create_module', $data['workflows'] ?? []);
+    }
+
+    public function test_agents_md_points_to_agent_pack(): void
+    {
+        $path = $this->root . '/AGENTS.md';
+        $this->assertFileExists($path);
+
+        $content = (string) file_get_contents($path);
+        $this->assertStringContainsString('docs/agent/upmvc-knowledge.json', $content);
+        $this->assertStringContainsString('upmvc-next.php', $content);
+        $this->assertStringContainsString('docs/AGENT_PACK.md', $content);
+    }
+
+    public function test_agent_pack_guide_exists(): void
+    {
+        $path = $this->root . '/docs/AGENT_PACK.md';
+        $this->assertFileExists($path);
+
+        $content = (string) file_get_contents($path);
+        $this->assertStringContainsString('upmvc-next.php', $content);
+        $this->assertStringContainsString('upmvc-rules.json', $content);
+    }
+
+    public function test_agent_pack_json_not_stale(): void
+    {
+        $knowledge = json_decode(
+            (string) file_get_contents($this->agentDir . '/upmvc-knowledge.json'),
+            true
+        );
+        $rules = json_decode(
+            (string) file_get_contents($this->agentDir . '/upmvc-rules.json'),
+            true
+        );
+
+        $this->assertIsString($knowledge['meta']['version'] ?? null);
+        $this->assertNotEmpty($knowledge['meta']['version'] ?? null);
+        $this->assertStringContainsString('v2.3', (string) ($knowledge['meta']['verified_against'] ?? ''));
+
+        $rulesBlob = json_encode($rules);
+        $this->assertIsString($rulesBlob);
+        $this->assertStringContainsString('InitModsImproved', $rulesBlob);
+        $this->assertStringNotContainsString('InitMods when', $rulesBlob);
+
+        $saasPath = $this->agentDir . '/upmvc-saas-pack.json';
+        if (!is_file($saasPath)) {
+            return;
+        }
+
+        $saas = json_decode((string) file_get_contents($saasPath), true);
+        $saasBlob = json_encode($saas);
+        $this->assertIsString($saasBlob);
+        $this->assertStringContainsString('addRoute', $saasBlob);
+        $this->assertStringNotContainsString('->middleware(', $saasBlob);
+        $this->assertStringNotContainsString('Billing', $saasBlob);
+    }
+
+    public function test_knowledge_pack_documents_canonical_env_path(): void
+    {
+        $knowledge = json_decode(
+            (string) file_get_contents($this->agentDir . '/upmvc-knowledge.json'),
+            true
+        );
+
+        $this->assertSame('src/Etc/.env', $knowledge['paths']['env_file'] ?? null);
+    }
+}

--- a/tests/Unit/Tools/UpmvcNextCliTest.php
+++ b/tests/Unit/Tools/UpmvcNextCliTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Unit\Tools;
+
+use PHPUnit\Framework\TestCase;
+
+class UpmvcNextCliTest extends TestCase
+{
+    private string $root;
+    private string $script;
+    private string $generatedDir;
+    /** @var list<string> */
+    private array $filesToCleanup = [];
+
+    protected function setUp(): void
+    {
+        $this->root = dirname(__DIR__, 3);
+        $this->script = $this->root . '/src/Tools/upmvc-next.php';
+        $this->generatedDir = $this->root . '/docs/agent/generated';
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->filesToCleanup as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+        $this->filesToCleanup = [];
+    }
+
+    public function test_cli_script_exists(): void
+    {
+        $this->assertFileExists($this->script);
+    }
+
+    public function test_stdout_mode_exits_zero_and_contains_goal(): void
+    {
+        $result = $this->runCli([
+            '--goal',
+            'Add a contact form module',
+            '--stdout',
+        ]);
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertStringContainsString('you are already inside the house', $result['output']);
+        $this->assertStringContainsString('Add a contact form module', $result['output']);
+        $this->assertStringContainsString('Workflow: `create_module`', $result['output']);
+    }
+
+    public function test_config_audit_goal_maps_to_config_audit_workflow(): void
+    {
+        $result = $this->runCli([
+            '--goal',
+            'Audit my .env config wiring',
+            '--stdout',
+        ]);
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertStringContainsString('Workflow: `config_audit`', $result['output']);
+    }
+
+    public function test_default_mode_writes_generated_files(): void
+    {
+        $goal = 'Test agent pack output ' . uniqid('', true);
+
+        $result = $this->runCli(['--goal', $goal]);
+
+        $this->assertSame(0, $result['exit'], $result['output']);
+        $this->assertFileExists($this->generatedDir . '/last-prompt.md');
+        $this->assertFileExists($this->generatedDir . '/last-session.json');
+
+        $session = json_decode(
+            (string) file_get_contents($this->generatedDir . '/last-session.json'),
+            true
+        );
+
+        $this->assertIsArray($session);
+        $this->assertSame($goal, $session['goal'] ?? null);
+        $this->assertArrayHasKey('scan', $session);
+        $this->assertGreaterThan(0, $session['scan']['module_count'] ?? 0);
+
+        $prompt = (string) file_get_contents($this->generatedDir . '/last-prompt.md');
+        $this->assertStringContainsString($goal, $prompt);
+        $this->assertStringContainsString('upmvc-knowledge.json', $prompt);
+
+        $this->filesToCleanup[] = $this->generatedDir . '/last-prompt.md';
+        $this->filesToCleanup[] = $this->generatedDir . '/last-session.json';
+    }
+
+    public function test_runs_when_saas_pack_json_missing(): void
+    {
+        $saasFile = $this->root . '/docs/agent/upmvc-saas-pack.json';
+        $backup = $saasFile . '.bak-test';
+
+        if (!is_file($saasFile)) {
+            $this->markTestSkipped('upmvc-saas-pack.json not present in this checkout');
+        }
+
+        rename($saasFile, $backup);
+
+        try {
+            $result = $this->runCli(['--goal', 'Smoke test without SaaS pack file', '--stdout']);
+            $this->assertSame(0, $result['exit'], $result['output']);
+            $this->assertStringContainsString('Smoke test without SaaS pack file', $result['output']);
+        } finally {
+            if (is_file($backup) && !is_file($saasFile)) {
+                rename($backup, $saasFile);
+            }
+        }
+    }
+
+    /** @param list<string> $args */
+    private function runCli(array $args): array
+    {
+        $cmd = escapeshellarg(PHP_BINARY)
+            . ' '
+            . escapeshellarg($this->script);
+
+        foreach ($args as $arg) {
+            $cmd .= ' ' . escapeshellarg($arg);
+        }
+
+        $output = [];
+        $exitCode = 0;
+        exec($cmd . ' 2>&1', $output, $exitCode);
+
+        return [
+            'output' => implode("\n", $output),
+            'exit' => $exitCode,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a versioned JSON agent pack (`docs/agent/`) with framework facts, must/never rules, workflows, and optional SaaS pack context aligned to upMVC v2.3.6
- Adds `src/Tools/upmvc-next.php` — scans the project, asks what you want, outputs a ready-to-paste agent prompt (`docs/agent/generated/`, gitignored)
- Adds `AGENTS.md`, `docs/AGENT_PACK.md`, README/docs index links, and `tests/Unit/Tools/` smoke tests (12 tests)

## Test plan
- [x] `vendor\bin\phpunit tests\Unit\Tools` — 12/12 passing
- [x] `php src/Tools/upmvc-next.php --goal "Add a contact form module" --stdout`
- [x] CLI runs when `upmvc-saas-pack.json` is absent (standalone installs)
- [ ] Paste `docs/agent/generated/last-prompt.md` into Cursor and confirm context loads sensibly
