### PR TITLE
Document kernel surface (boot, config, router)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,8 @@ You are working inside an **upMVC** PHP project. Do not ask the user to explain 
 ## Load first
 
 - `docs/AGENT_PACK.md` — full usage guide
-- `docs/agent/upmvc-knowledge.json` — paths, bootstrap, config, modules, packages
+- `docs/KERNEL.md` — kernel surface (boot, config, router, packages) — product is `src/Etc/`
+- `docs/agent/upmvc-knowledge.json` — paths, bootstrap, `kernel_surface`, modules, packages
 - `docs/agent/upmvc-rules.json` — must/never constraints
 - `docs/agent/upmvc-workflows.json` — match user intent to a recipe
 
@@ -23,9 +24,11 @@ For **new module scaffolding** (optional, not default):
 2. Run or simulate `php src/Tools/upmvc-next.php` for project scan + prompt package.
 3. Output a **plan** (JSON) before multi-file edits.
 4. Follow `upmvc-rules.json` strictly; scope SaaS queries with `tenant_id`.
+5. Kernel work: claim capabilities only from `src/Etc/` / `docs/KERNEL.md` — never from demos.
 
 ## Docs
 
+- `docs/KERNEL.md`
 - `docs/MODULE_PHILOSOPHY.md`
 - `docs/CORE_AREAS_AND_CONFIGURATION.md`
 - `docs/agent/README.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,8 @@
 
 ## [Unreleased]
 
-### Changed — thin create-project (Welcome only)
-- **Stock tree ships `Welcome` only.** Optional demos (Auth, Test, Admin, React*, User, …) leave git; keep them locally or download `upmvc-demos.zip` from Releases and paste into `src/Modules/`.
-- **`/` and `/index.php`** are owned by `src/Etc/custom-routes.php` → `App\Modules\Welcome\Controller` (no DB, no auth). Apps replace that entry anytime.
-- **`Test` no longer registers `/`** — demos live under `/test` and friends.
-- **`.gitignore`** ignores `/src/Modules/*` except `Welcome/`. Optional demos ship as a Releases zip asset (maintainer-built from local copies — not from the public tree).
-
-### Fixed (demo pack, before zip)
-- **Auth signup** uses `MAIL_FROM_ADDRESS` from `.env` instead of a hardcoded BitsWorld address.
-- **`/apiUsers` JSON** no longer includes password hashes.
+### Docs
+- **`docs/KERNEL.md`** — kernel surface (boot, config, router, packages); agent `kernel_surface` + rules so claims stay tied to `src/Etc/`, not demos.
 
 ### CI
 - **`.github/workflows/ci.yml`** — PHPStan and PHPUnit on every push and pull request, across PHP 8.1–8.4 with Composer caching. Neither tool needs a database, so the run is self-contained.
@@ -96,6 +89,20 @@ real namespaces, router methods tested for existence) rather than by reading.
 - **`README.md`** — the standalone install is now four steps, not three. Following the documented three produced `SQLSTATE[HY000] [1049] Unknown database 'your_database'` on the homepage: the bundled modules open a database connection on boot, so `DB_NAME` must point at a database that exists. An **empty** one is sufficient — no schema import is required to get the site rendering. Verified end to end with `composer create-project` against a freshly created empty database.
 
 ---
+
+## v2.5.0 - Thin Core (2026-08-02)
+
+Stock create-project / clone is light boilerplate: kernel + **Welcome** homepage. Full demo suite is optional (`upmvc-demos.zip` on the Release).
+
+### Changed
+- **Stock tree ships `Welcome` only.** Optional demos leave git; keep them locally or download from Releases and paste into `src/Modules/`.
+- **`/` and `/index.php`** owned by `src/Etc/custom-routes.php` → `App\Modules\Welcome\Controller` (no DB, no auth).
+- **`Test` no longer registers `/`** — demos live under `/test` and friends.
+- **`.gitignore`** ignores `/src/Modules/*` except `Welcome/`. Maintainer demos-zip script is local-only (not public).
+
+### Fixed (in the demos zip pack)
+- **Auth signup** uses `MAIL_FROM_ADDRESS` from `.env` instead of a hardcoded BitsWorld address.
+- **`/apiUsers` JSON** no longer includes password hashes.
 
 ## v2.4.0 - Migration Runner, Database Tooling & Autoload Fixes (2026-07-29)
 

--- a/docs/AGENT_PACK.md
+++ b/docs/AGENT_PACK.md
@@ -108,6 +108,7 @@ Always pair **knowledge + rules** for core work. Scaffolds and SaaS packs are **
 
 Framework facts an agent should not re-discover each session:
 
+- **`kernel_surface`** — product boundary (`src/Etc/`), boot order, config/router/packages contracts (see also [`docs/KERNEL.md`](KERNEL.md))
 - Bootstrap flow (`public/index.php` → `Start.php` → routing)
 - Paths (`src/Etc/.env` — canonical runtime path via `Environment::load()`, not project-root `.env`)
 - Config access (`Environment::get()`, `ConfigManager::get()`)

--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -1,0 +1,149 @@
+# upMVC Kernel
+
+The **product** is `src/Etc/` (plus `public/index.php` and the Composer package boundary).  
+Modules under `src/Modules/` are optional. Demos are a Releases zip. Do not infer kernel limits from demos.
+
+Verified against **2.5.0** (Thin Core). Claims below are from running code in `src/Etc/`, not from marketing copy.
+
+---
+
+## What is in / out
+
+| In (kernel) | Out (not kernel) |
+|-------------|------------------|
+| Boot, config, router, middleware, security helpers | Auth / Test / React / Admin demos |
+| `Application` package hooks | Welcome UI (app-owned homepage module) |
+| Cache manager, JWT service, events, helpers | Anything under `src/Modules/*` except what *you* add |
+| Tools: `doctor`, `migrate`, `cache-cli`, agent CLI | Maintainer-only zip builders (local / gitignored) |
+
+`src/Common/` is shared base classes for *apps* (BaseModel, BaseView, …). Useful with the kernel; not the kernel’s public “framework API” in the same sense as `Router` / `Application`.
+
+---
+
+## Boot (entry → dispatch)
+
+```
+public/index.php
+  define UPMVC_APP_ROOT
+  require vendor/autoload.php
+  new Start()                    → ConfigManager::load(), ErrorHandler, parse route
+  Start::upMVC()
+    new Router()
+    HelperFacade::setRouter()
+    Application::registerProviders()     ← packages.php
+    global middleware (logging, optional CORS, AuthMiddleware)
+    named middleware (csrf, rate_limit, jwt, auth, cors, …)
+    Application::bootProviders($router)
+    Routes::startRoutes()
+      for each Application::getModulePathsForRoutes():
+        InitModsImproved::addRoutes()    ← discover + custom-routes.php last
+      Router::dispatch(...)
+```
+
+**Honesty notes (boot)**
+
+- Boot does **not** open a database. PDO opens when something constructs `Database` / `BaseModel`. Welcome needs no DB.
+- `Start::$defaultProtectedRoutes` still lists demo-ish prefixes (`/admin/*`, `/moda`, …). Override with `PROTECTED_ROUTES` in `.env` or `Application::addProtectedRoutes()`. Cleaning those defaults is a future kernel honesty fix — not done in this doc-only pass.
+- Library mode: define `UPMVC_APP_ROOT` *before* autoload so `Application` and `Environment` resolve the **host** app paths (`.env`, `packages.php`, `src/Modules`).
+
+---
+
+## Config surface
+
+| Layer | Role |
+|-------|------|
+| `src/Etc/.env` via `Environment::get()` | Canonical runtime values (`Application::path('src/Etc/.env')`) |
+| `ConfigManager::get('dot.key')` | Structured app / database / cache / session / security / mail / logging |
+| `Config.php` | Legacy URL helpers (`getReqRoute`, `BASE_URL` / site path fallbacks) |
+| `ConfigDatabase.php` | DB fallbacks when env incomplete (dev-oriented) |
+
+**Read config with** `Environment::get()` or `ConfigManager::get()` — not `$_ENV` for `.env` keys (`putenv` does not populate `$_ENV`).
+
+**Required-ish env:** `DOMAIN_NAME`, `SITE_PATH`, `APP_ENV`. Use `APP_DEBUG` for error display. Validate warnings are logged; they do not always hard-stop boot.
+
+See also: `docs/CORE_AREAS_AND_CONFIGURATION.md`, `docs/CONFIGURATION_FALLBACKS.md`.
+
+---
+
+## Router surface
+
+### Registration APIs (real)
+
+```php
+$router->addRoute($path, $class, $method, array $middleware = [], array $methods = []);
+// returns void — do NOT chain ->name() on addRoute
+
+$router->addParamRoute($pattern, $class, $method, $middleware = [], $constraints = [], $methods = []);
+// returns $this — ->name() is valid here
+```
+
+There is **no** `$router->get()`, `->group()`, or `->middleware()` fluent group API. Named middleware is the 4th argument array on `addRoute` / `addParamRoute`.
+
+### Discovery order
+
+1. Package / extra module paths first (`Application::getModulePathsForRoutes()` — app `src/Modules` scanned **last** so local routes can override packs).
+2. Per path: `InitModsImproved` finds `*/Routes/Routes.php` (and nested `*/Modules/*/Routes/Routes.php` when enabled).
+3. Then `src/Etc/custom-routes.php` — each entry `addRoute`s; **same path overwrites**. Stock `/` → `Welcome\Controller`.
+
+Modules without `Routes/Routes.php` are invisible to discovery (Welcome is intentional: homepage only via `custom-routes.php`).
+
+### Dispatch contract
+
+Controllers are invoked with **`(string $route, string $method)`** (plus original URI available to middleware). Methods that need extra required args are not router-compatible.
+
+HTTP status: missing route → 404; wrong method → 405 + `Allow` (guarded by integration tests).
+
+---
+
+## Package / provider surface
+
+Optional `src/Etc/packages.php`:
+
+```php
+return [ \Vendor\Package\ServiceProvider::class, ... ];
+```
+
+| Hook | When | Purpose |
+|------|------|---------|
+| `registerProviders()` | Before middleware | Paths, migrations, protected routes, factories |
+| `bootProviders($router)` | After named middleware | Wire routes that need the router |
+
+`Application` APIs: `path()`, `addModulePath()`, `addMigrationPath()`, `addProtectedRoutes()`, `getModulePathsForRoutes()`.
+
+SaaS pack (`bitshost/upmvc-saas-pack`) is the primary interoperability stress test — kernel changes must not silently break it.
+
+---
+
+## Kernel tools (CLI)
+
+| Tool | Role |
+|------|------|
+| `php src/Tools/doctor.php` | Report modules discovery cannot see |
+| `php src/Tools/migrate.php` | Apply migrations; regenerate `database/schema.sql` |
+| `php src/Tools/cache-cli.php` | Cache stores / module discovery cache |
+| `php src/Tools/upmvc-next.php` | Agent prompt pack (not runtime) |
+
+---
+
+## Short audit — boot / config / router only (2.5.0)
+
+| Area | Finding | Severity | Next step (later) |
+|------|---------|----------|-------------------|
+| Boot | No DB on boot — Welcome-safe | OK | Keep |
+| Boot | Default protected routes smell like demos | Low | Slim defaults to `[]` or documented stubs |
+| Config | `.env` via `Application::path` — correct for library mode | OK | Keep documenting `UPMVC_APP_ROOT` |
+| Config | Dual legacy (`Config` / `ConfigDatabase`) still in play | Medium | Prefer ConfigManager; deprecate gradually |
+| Router | `custom-routes` overwrite is the homepage contract | OK | Treat as public |
+| Router | Discovery requires `Routes/Routes.php` | OK | Document; `doctor` already explains misses |
+| Router | `addRoute` void vs `addParamRoute` chainable | OK | Already corrected in routing docs |
+| Packages | Path order: packs then app | OK | SaaS regression = CI / manual smoke |
+
+No code changes in this pass — documentation + agent knowledge only.
+
+---
+
+## Agent entry
+
+- Facts: `docs/agent/upmvc-knowledge.json` → `kernel_surface`
+- Rules: `docs/agent/upmvc-rules.json`
+- This file: load for any kernel-focused session (`AGENTS.md`)

--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -3,7 +3,7 @@
 The **product** is `src/Etc/` (plus `public/index.php` and the Composer package boundary).  
 Modules under `src/Modules/` are optional. Demos are a Releases zip. Do not infer kernel limits from demos.
 
-Verified against **2.5.0** (Thin Core). Claims below are from running code in `src/Etc/`, not from marketing copy.
+Verified against **v2.5.0** (Thin Core). Claims below are from running code in `src/Etc/`, not from marketing copy.
 
 ---
 
@@ -125,7 +125,7 @@ SaaS pack (`bitshost/upmvc-saas-pack`) is the primary interoperability stress te
 
 ---
 
-## Short audit — boot / config / router only (2.5.0)
+## Short audit — boot / config / router only (v2.5.0)
 
 | Area | Finding | Severity | Next step (later) |
 |------|---------|----------|-------------------|

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -14,12 +14,14 @@ Paste `generated/last-prompt.md` into your agent chat.
 
 | File | Purpose |
 |------|---------|
-| `upmvc-knowledge.json` | Framework facts |
+| `upmvc-knowledge.json` | Framework facts + `kernel_surface` |
 | `upmvc-rules.json` | Must / never rules |
 | `upmvc-workflows.json` | Intent → recipe mapping |
 | `upmvc-scaffolds.json` | Module builder (optional — `--scaffold`) |
 | `upmvc-saas-pack.json` | SaaS pack (when applicable) |
 | `generated/` | CLI output (gitignored) |
+
+**Kernel product doc:** [../KERNEL.md](../KERNEL.md) — boot, config, router, packages; claims from `src/Etc/` only.
 
 ## Updating rules
 

--- a/docs/agent/upmvc-knowledge.json
+++ b/docs/agent/upmvc-knowledge.json
@@ -1,29 +1,88 @@
 {
   "meta": {
     "name": "upMVC Agent Knowledge Pack",
-    "version": "1.0.1",
-    "verified_against": "upMVC v2.4.0",
+    "version": "1.1.0",
+    "verified_against": "upMVC 2.5.0",
     "framework": "upMVC",
     "php_minimum": "8.1",
     "purpose": "Portable startup context for any AI agent working on upMVC or upMVC-SaaS projects",
     "usage": "Load this file at session start together with upmvc-rules.json. Do not ask the user to explain framework basics."
   },
   "philosophy": {
-    "summary": "Pure PHP MVC. Modules are optional reference implementations. Minimal core, explicit control, no ORM required.",
+    "summary": "Pure PHP MVC. The product is the kernel (src/Etc/). Modules are optional. Minimal core, explicit control, no ORM required.",
     "principles": [
+      "Kernel claims come from src/Etc/ running code — not from demos or marketing",
       "Modules auto-discovered — drop folder in src/Modules, routes register automatically",
       "PDO prepared statements — no magic query builder required",
       "Config from .env via Environment::get() and ConfigManager::get()",
       "Framework stays out of the way — app-specific patterns belong in app layer, not core"
     ],
     "docs": [
+      "docs/KERNEL.md",
       "docs/MODULE_PHILOSOPHY.md",
       "docs/PHILOSOPHY_PURE_PHP.md",
       "docs/CORE_AREAS_AND_CONFIGURATION.md",
       "docs/CONFIGURATION_FALLBACKS.md"
     ]
   },
-  "paths": {
+  "kernel_surface": {
+    "doc": "docs/KERNEL.md",
+    "product": "src/Etc/ (+ public/index.php, Composer package boundary)",
+    "not_product": [
+      "Optional demos (Releases zip)",
+      "Welcome UI chrome (homepage module only)",
+      "src/Common base classes (app helpers, not the kernel contract)"
+    ],
+    "public_classes": [
+      "App\\Etc\\Start",
+      "App\\Etc\\Application",
+      "App\\Etc\\Routes",
+      "App\\Etc\\Router",
+      "App\\Etc\\InitModsImproved",
+      "App\\Etc\\Config\\Environment",
+      "App\\Etc\\Config\\ConfigManager",
+      "App\\Etc\\Security",
+      "App\\Etc\\JwtService",
+      "App\\Etc\\Cache\\CacheManager",
+      "App\\Etc\\Middleware\\*"
+    ],
+    "boot_order": [
+      "public/index.php defines UPMVC_APP_ROOT + autoload",
+      "Start constructs → ConfigManager::load(), ErrorHandler, Config::getReqRoute",
+      "Start::upMVC → Router, registerProviders, global+named middleware, bootProviders",
+      "Routes::startRoutes → InitModsImproved per module path, then custom-routes.php, then dispatch"
+    ],
+    "config_contract": {
+      "env_file": "Application::path('src/Etc/.env') via Environment::load()",
+      "read": ["Environment::get()", "ConfigManager::get()"],
+      "avoid": "$_ENV for .env keys",
+      "legacy_fallbacks": ["Config.php", "ConfigDatabase.php"]
+    },
+    "router_contract": {
+      "addRoute": "exact path; returns void; middleware 4th arg; same path overwrites",
+      "addParamRoute": "pattern with {id:int}; returns $this (chain ->name())",
+      "no_apis": ["get()", "group()", "fluent middleware() groups"],
+      "controller_signature": "(string $route, string $method)",
+      "custom_routes": "src/Etc/custom-routes.php after discovery — stock '/' → Welcome",
+      "discovery": "*/Routes/Routes.php only — modules without it are invisible"
+    },
+    "packages_contract": {
+      "registry": "optional src/Etc/packages.php",
+      "register_then_boot": "registerProviders before middleware; bootProviders after",
+      "path_order": "getModulePathsForRoutes — packs first, app src/Modules last",
+      "interop_test": "bitshost/upmvc-saas-pack"
+    },
+    "tools": [
+      "php src/Tools/doctor.php",
+      "php src/Tools/migrate.php",
+      "php src/Tools/cache-cli.php",
+      "php src/Tools/upmvc-next.php"
+    ],
+    "audit_open": [
+      "Start::$defaultProtectedRoutes still lists demo-ish prefixes — override via PROTECTED_ROUTES",
+      "Legacy Config.php / ConfigDatabase.php still in the stack — prefer ConfigManager"
+    ]
+  },  "paths": {
     "app_root": "UPMVC_APP_ROOT or project root (dirname above src/)",
     "entry": "public/index.php",
     "env_file": "src/Etc/.env",

--- a/docs/agent/upmvc-knowledge.json
+++ b/docs/agent/upmvc-knowledge.json
@@ -2,7 +2,7 @@
   "meta": {
     "name": "upMVC Agent Knowledge Pack",
     "version": "1.1.0",
-    "verified_against": "upMVC 2.5.0",
+    "verified_against": "upMVC v2.5.0",
     "framework": "upMVC",
     "php_minimum": "8.1",
     "purpose": "Portable startup context for any AI agent working on upMVC or upMVC-SaaS projects",

--- a/docs/agent/upmvc-rules.json
+++ b/docs/agent/upmvc-rules.json
@@ -2,7 +2,7 @@
   "meta": {
     "name": "upMVC Agent Rules",
     "version": "1.1.0",
-    "verified_against": "upMVC 2.5.0",
+    "verified_against": "upMVC v2.5.0",
     "severity": "These are hard constraints. Violations must be fixed before code is accepted."
   },
   "must": [

--- a/docs/agent/upmvc-rules.json
+++ b/docs/agent/upmvc-rules.json
@@ -1,11 +1,13 @@
 {
   "meta": {
     "name": "upMVC Agent Rules",
-    "version": "1.0.1",
-    "verified_against": "upMVC v2.4.0",
+    "version": "1.1.0",
+    "verified_against": "upMVC 2.5.0",
     "severity": "These are hard constraints. Violations must be fixed before code is accepted."
   },
   "must": [
+    "Treat src/Etc/ as the kernel product — load docs/KERNEL.md and knowledge.kernel_surface for kernel work",
+    "State kernel capabilities only from src/Etc/ (or docs/KERNEL.md) — never from demo modules",
     "Read config with Environment::get() or ConfigManager::get() — never $_ENV for .env values",
     "Place new modules under src/Modules/{Name}/ with Routes/Routes.php for auto-discovery",
     "Use namespace App\\Modules\\{Name} for application modules",


### PR DESCRIPTION
## Summary
- Add `docs/KERNEL.md` — product is `src/Etc/`; boot/config/router/packages contracts verified against 2.5.0
- Add `kernel_surface` to agent knowledge + rules so agents claim capabilities from the kernel, not demos
- Wire into `AGENTS.md`, agent README, and `AGENT_PACK.md`
- Docs only — short audit notes open items (demo-ish protected-route defaults; legacy Config fallbacks)

## Test plan
- [ ] Skim `docs/KERNEL.md` against `Start` / `Routes` / `Router` / `Environment`
- [ ] Confirm `docs/agent/upmvc-knowledge.json` and `upmvc-rules.json` still parse as JSON
- [ ] No runtime/CI impact expected (documentation only)